### PR TITLE
feat: add StrategyBadge component and wire through vaults

### DIFF
--- a/harvest-finance/frontend/src/app/vaults/page.tsx
+++ b/harvest-finance/frontend/src/app/vaults/page.tsx
@@ -28,6 +28,7 @@ const MOCK_VAULTS: Vault[] = [
     walletBalance: "5000.00",
     iconName: "Coins",
     seasonalTarget: 5000,
+    strategyType: "Audited",
   },
   {
     id: "2",
@@ -40,6 +41,7 @@ const MOCK_VAULTS: Vault[] = [
     walletBalance: "12,450.00",
     iconName: "Zap",
     seasonalTarget: 10000,
+    strategyType: "Community",
   },
   {
     id: "3",
@@ -52,6 +54,7 @@ const MOCK_VAULTS: Vault[] = [
     walletBalance: "1,200.00",
     iconName: "Leaf",
     seasonalTarget: 2000,
+    strategyType: "Audited",
   },
   {
     id: "4",
@@ -64,6 +67,7 @@ const MOCK_VAULTS: Vault[] = [
     walletBalance: "2500.00",
     iconName: "Shield",
     seasonalTarget: 20000,
+    strategyType: "Experimental",
   },
 ];
 

--- a/harvest-finance/frontend/src/components/dashboard/VaultCard.tsx
+++ b/harvest-finance/frontend/src/components/dashboard/VaultCard.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import React from 'react';
-import { Card, CardHeader, CardBody, CardFooter, Button, Badge, Stack, Inline } from '@/components/ui';
+import { Card, CardHeader, CardBody, CardFooter, Button, Badge, Stack, Inline, StrategyBadge } from '@/components/ui';
 import { TrendingUp, Wallet, ArrowUpRight, ArrowDownLeft } from 'lucide-react';
+import { StrategyType } from '@/types/vault';
 
 export interface VaultProps {
   id: string;
@@ -13,6 +14,7 @@ export interface VaultProps {
   balance: string;
   walletBalance: string;
   icon: React.ReactNode;
+  strategyType?: StrategyType;
   onDeposit: (vaultId: string) => void;
   onWithdraw: (vaultId: string) => void;
 }
@@ -26,6 +28,7 @@ export const VaultCard: React.FC<VaultProps> = ({
   balance,
   walletBalance,
   icon,
+  strategyType,
   onDeposit,
   onWithdraw,
 }) => {
@@ -39,6 +42,7 @@ export const VaultCard: React.FC<VaultProps> = ({
             </div>
             <div>
               <h3 className="text-lg font-bold text-gray-900 dark:text-zinc-50">{name}</h3>
+              {strategyType && <StrategyBadge strategyType={strategyType} />}
               <p className="text-sm text-gray-500 dark:text-zinc-400">{asset} Vault</p>
             </div>
           </div>

--- a/harvest-finance/frontend/src/components/dashboard/VaultTable.tsx
+++ b/harvest-finance/frontend/src/components/dashboard/VaultTable.tsx
@@ -11,6 +11,7 @@ import {
   Badge,
   Button,
   Inline,
+  StrategyBadge,
 } from '@/components/ui';
 import { 
   ArrowUpDown, 
@@ -121,6 +122,7 @@ export const VaultTable: React.FC<VaultTableProps> = ({
                 {renderSortIcon('riskLevel')}
               </Inline>
             </TableHead>
+            <TableHead>Strategy</TableHead>
             <TableHead className="text-right">Actions</TableHead>
           </TableRow>
         </TableHeader>
@@ -151,6 +153,9 @@ export const VaultTable: React.FC<VaultTableProps> = ({
                   {vault.riskLevel}
                 </Badge>
               </TableCell>
+              <TableCell>
+                {vault.strategyType ? <StrategyBadge strategyType={vault.strategyType} /> : <span className="text-gray-400">—</span>}
+              </TableCell>
               <TableCell className="text-right">
                 <div className="flex justify-end gap-2 items-center">
                   <Button 
@@ -176,7 +181,7 @@ export const VaultTable: React.FC<VaultTableProps> = ({
           ))}
           {sortedVaults.length === 0 && (
             <TableRow>
-              <TableCell colSpan={5} className="h-24 text-center text-gray-500">
+              <TableCell colSpan={6} className="h-24 text-center text-gray-500">
                 No vaults found.
               </TableCell>
             </TableRow>

--- a/harvest-finance/frontend/src/components/ui/Badge/StrategyBadge.tsx
+++ b/harvest-finance/frontend/src/components/ui/Badge/StrategyBadge.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { ShieldCheck, Users, FlaskConical } from 'lucide-react';
+import { Badge } from './Badge';
+import { StrategyType } from '@/types/vault';
+
+const config: Record<StrategyType, { variant: 'success' | 'info' | 'warning'; icon: React.ReactNode; title: string }> = {
+  Audited: {
+    variant: 'success',
+    icon: <ShieldCheck className="w-3 h-3" />,
+    title: 'Smart contract audited by a third party',
+  },
+  Community: {
+    variant: 'info',
+    icon: <Users className="w-3 h-3" />,
+    title: 'Community-governed strategy',
+  },
+  Experimental: {
+    variant: 'warning',
+    icon: <FlaskConical className="w-3 h-3" />,
+    title: 'New or unaudited strategy — use with caution',
+  },
+};
+
+export const StrategyBadge: React.FC<{ strategyType: StrategyType }> = ({ strategyType }) => {
+  const { variant, icon, title } = config[strategyType];
+  return (
+    <Badge variant={variant} size="sm" isPill title={title} className="inline-flex items-center gap-1">
+      {icon}
+      {strategyType}
+    </Badge>
+  );
+};

--- a/harvest-finance/frontend/src/components/ui/Badge/index.ts
+++ b/harvest-finance/frontend/src/components/ui/Badge/index.ts
@@ -1,2 +1,3 @@
 export { Badge, StatusBadge } from './Badge';
 export type { BadgeProps } from './Badge';
+export { StrategyBadge } from './StrategyBadge';

--- a/harvest-finance/frontend/src/components/ui/index.ts
+++ b/harvest-finance/frontend/src/components/ui/index.ts
@@ -24,7 +24,7 @@ export type { InputProps, TextareaProps } from './Input';
 export { Modal, ModalHeader, ModalBody, ModalFooter } from './Modal';
 export type { ModalProps, ModalHeaderProps, ModalBodyProps, ModalFooterProps } from './Modal';
 
-export { Badge, StatusBadge } from './Badge';
+export { Badge, StatusBadge, StrategyBadge } from './Badge';
 export type { BadgeProps } from './Badge';
 
 export { Container, Section, Stack, Inline } from './Container';

--- a/harvest-finance/frontend/src/types/vault.ts
+++ b/harvest-finance/frontend/src/types/vault.ts
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 
 export type RiskLevel = 'Low' | 'Medium' | 'High';
+export type StrategyType = 'Audited' | 'Community' | 'Experimental';
 
 export interface Vault {
   id: string;
@@ -14,6 +15,7 @@ export interface Vault {
   icon?: ReactNode;
   iconName?: string; // For dynamic loading or references
   seasonalTarget: number;
+  strategyType?: StrategyType;
   projections?: {
     progressPercentage: number;
   };


### PR DESCRIPTION
closes #184 

 Adds a `StrategyBadge` UI component that visually communicates the strategy type of each vault, and wires it through the vault type, mock data,         
  `VaultCard`, and `VaultTable`.                                                                                                                          
                                                                                                                                                          
  ## Changes                                                                                                                                              
                                                                                                                                                          
  - **`src/types/vault.ts`** — Added `strategyType?: 'Audited' | 'Community' | 'Experimental'` to the `Vault` interface                                   
  - **`src/components/ui/Badge/StrategyBadge.tsx`** — New reusable badge component mapping each strategy type to a variant + lucide icon:                 
    - `Audited` → green, `ShieldCheck`                                                                                                                    
    - `Community` → blue, `Users`                                                                                                                         
    - `Experimental` → amber, `FlaskConical`                                                                                                              
  - **`src/components/ui/Badge/index.ts`** — Exported `StrategyBadge`                                                                                     
  - **`src/components/ui/index.ts`** — Exported `StrategyBadge` from the main UI barrel                                                                   
  - **`src/app/vaults/page.tsx`** — Assigned `strategyType` to all 4 mock vaults                                                                          
  - **`src/components/dashboard/VaultCard.tsx`** — Renders `<StrategyBadge>` below the vault name when `strategyType` is present                          
  - **`src/components/dashboard/VaultTable.tsx`** — Added a "Strategy" column between "Risk Level" and "Actions"                                          
                                                                                                                                                          
  ## Testing                                                                                                                                              
                                                                                                                                                          
  - `tsc --noEmit` passes with zero errors                                                                                                                
  - No new dependencies added (uses `lucide-react` already in the project)                                                                                
  - No existing Badge variants or core Badge component modified   
  -   -   -    -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   - 