### PR TITLE
feat: add skeleton loaders for async loading states (#185 #119)

### DIFF
--- a/harvest-finance/frontend/src/app/dashboard/page.tsx
+++ b/harvest-finance/frontend/src/app/dashboard/page.tsx
@@ -13,7 +13,8 @@ import {
   Badge, 
   Button, 
   Card, 
-  CardBody 
+  CardBody,
+  MetricCardSkeleton,
 } from '@/components/ui';
 
 import { AIAssistantChat } from '@/components/ai-assistant';
@@ -189,7 +190,9 @@ export default function DashboardPage() {
       <MilestoneNotification />
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        {quickActions.map((card) => {
+        {isSyncing
+          ? Array.from({ length: 4 }).map((_, i) => <MetricCardSkeleton key={i} />)
+          : quickActions.map((card) => {
           const Icon = card.icon;
           return (
             <Card key={card.title} variant="default" className="hover:shadow-md transition-shadow">

--- a/harvest-finance/frontend/src/app/transactions/page.tsx
+++ b/harvest-finance/frontend/src/app/transactions/page.tsx
@@ -16,6 +16,7 @@ import {
   Stack,
   Inline,
   ThemeToggle,
+  TransactionRowSkeleton,
 } from '@/components/ui';
 import { Download, ArrowRightLeft, Calendar, Tag, Coins, Info } from 'lucide-react';
 import { useAuthStore } from '@/lib/stores/auth-store';
@@ -33,6 +34,12 @@ const mockTransactions = [
 export default function TransactionsPage() {
   const { user, token } = useAuthStore();
   const [isExporting, setIsExporting] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const t = setTimeout(() => setIsLoading(false), 1000);
+    return () => clearTimeout(t);
+  }, []);
 
   const handleExport = async (format: 'csv' | 'excel') => {
     if (!user) return;
@@ -115,7 +122,9 @@ export default function TransactionsPage() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {mockTransactions.map((tx) => (
+              {isLoading
+                ? Array.from({ length: 5 }).map((_, i) => <TransactionRowSkeleton key={i} />)
+                : mockTransactions.map((tx) => (
                 <TableRow key={tx.id}>
                   <TableCell className="font-medium text-gray-900 dark:text-gray-200">
                     <div className="flex items-center gap-2">

--- a/harvest-finance/frontend/src/app/vaults/page.tsx
+++ b/harvest-finance/frontend/src/app/vaults/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Container, Section, Button, Inline, Stack, cn } from "@/components/ui";
+import { Container, Section, Button, Inline, Stack, cn, VaultCardSkeleton, VaultTableRowSkeleton } from "@/components/ui";
 import { DepositModal } from "@/components/dashboard/DepositModal";
 import { MilestoneConfetti } from "@/components/dashboard/MilestoneConfetti";
 import { ProgressBar } from "@/components/dashboard/ProgressBar";
@@ -122,6 +122,7 @@ function VaultWithProgress({
 export default function VaultsPage() {
   const { t } = useTranslation();
   const [selectedVault, setSelectedVault] = useState<Vault | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
   const [isDepositOpen, setIsDepositOpen] = useState(false);
   const [isWithdrawOpen, setIsWithdrawOpen] = useState(false);
   const [showConfetti, setShowConfetti] = useState(false);
@@ -190,6 +191,12 @@ export default function VaultsPage() {
     [vaultBalances, milestoneHooks],
   );
 
+
+  useEffect(() => {
+    const t = setTimeout(() => setIsLoading(false), 1000);
+    return () => clearTimeout(t);
+  }, []);
+
   const vaultsWithBalances = MOCK_VAULTS.map((vault) => {
     const balanceNum = vaultBalances[vault.id] ?? 0;
     return {
@@ -249,14 +256,24 @@ export default function VaultsPage() {
 
             {viewMode === 'grid' ? (
               <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                {vaultsWithBalances.map((vault) => (
-                  <VaultWithProgress
-                    key={vault.id}
-                    vault={vault as any}
-                    onDeposit={handleDepositClick}
-                    onWithdraw={handleWithdrawClick}
-                  />
-                ))}
+                {isLoading
+                  ? Array.from({ length: 4 }).map((_, i) => <VaultCardSkeleton key={i} />)
+                  : vaultsWithBalances.map((vault) => (
+                      <VaultWithProgress
+                        key={vault.id}
+                        vault={vault as any}
+                        onDeposit={handleDepositClick}
+                        onWithdraw={handleWithdrawClick}
+                      />
+                    ))}
+              </div>
+            ) : isLoading ? (
+              <div className="rounded-xl border border-gray-100 bg-white overflow-hidden shadow-sm">
+                <table className="w-full">
+                  <tbody>
+                    {Array.from({ length: 4 }).map((_, i) => <VaultTableRowSkeleton key={i} />)}
+                  </tbody>
+                </table>
               </div>
             ) : (
               <VaultTable 

--- a/harvest-finance/frontend/src/components/portfolio/TransactionTable.tsx
+++ b/harvest-finance/frontend/src/components/portfolio/TransactionTable.tsx
@@ -9,7 +9,8 @@ import {
   Badge, 
   StatusBadge, 
   Button,
-  Input
+  Input,
+  TransactionRowSkeleton,
 } from '@/components/ui';
 import { Transaction, TransactionType } from '@/lib/mock-data';
 import { Search, ChevronDown } from 'lucide-react';
@@ -17,9 +18,10 @@ import { useTranslation } from 'react-i18next';
 
 interface TransactionTableProps {
   transactions: Transaction[];
+  isLoading?: boolean;
 }
 
-export const TransactionTable: React.FC<TransactionTableProps> = ({ transactions }) => {
+export const TransactionTable: React.FC<TransactionTableProps> = ({ transactions, isLoading = false }) => {
   const { t } = useTranslation();
   const [searchTerm, setSearchTerm] = useState('');
   const [filterType, setFilterType] = useState<TransactionType | 'All'>('All');
@@ -79,6 +81,9 @@ export const TransactionTable: React.FC<TransactionTableProps> = ({ transactions
               </tr>
             </thead>
             <tbody>
+              {isLoading ? (
+                Array.from({ length: 5 }).map((_, i) => <TransactionRowSkeleton key={i} />)
+              ) : (
               <AnimatePresence mode="popLayout">
                 {filteredTransactions.slice(0, visibleCount).map((tx) => (
                   <motion.tr
@@ -114,6 +119,7 @@ export const TransactionTable: React.FC<TransactionTableProps> = ({ transactions
                   </motion.tr>
                 ))}
               </AnimatePresence>
+              )}
             </tbody>
           </table>
         </div>

--- a/harvest-finance/frontend/src/components/ui/Skeleton/Skeleton.tsx
+++ b/harvest-finance/frontend/src/components/ui/Skeleton/Skeleton.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { cn } from '@/components/ui/types';
+
+const shimmer = {
+  animate: { opacity: [0.4, 1, 0.4] },
+  transition: { duration: 1.5, repeat: Infinity, ease: 'easeInOut' },
+};
+
+export function Skeleton({ className }: { className?: string }) {
+  return (
+    <motion.div
+      className={cn('bg-slate-200 rounded-md', className)}
+      {...shimmer}
+    />
+  );
+}
+
+export function VaultCardSkeleton() {
+  return (
+    <div className="rounded-xl border border-gray-100 bg-white p-5 flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Skeleton className="w-10 h-10 rounded-full" />
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-20" />
+          </div>
+        </div>
+        <Skeleton className="h-6 w-16 rounded-full" />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="p-3 bg-gray-50 rounded-lg flex flex-col gap-2">
+          <Skeleton className="h-3 w-8" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+        <div className="p-3 bg-gray-50 rounded-lg flex flex-col gap-2">
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+      </div>
+      <Skeleton className="h-3 w-40" />
+      <div className="flex gap-2 pt-2 border-t border-gray-100">
+        <Skeleton className="h-9 flex-1 rounded-lg" />
+        <Skeleton className="h-9 flex-1 rounded-lg" />
+      </div>
+    </div>
+  );
+}
+
+export function VaultTableRowSkeleton() {
+  return (
+    <tr className="border-b border-gray-100">
+      <td className="py-4 px-4">
+        <div className="flex items-center gap-3">
+          <Skeleton className="w-8 h-8 rounded-full" />
+          <div className="flex flex-col gap-1">
+            <Skeleton className="h-4 w-28" />
+            <Skeleton className="h-3 w-12" />
+          </div>
+        </div>
+      </td>
+      <td className="py-4 px-4"><Skeleton className="h-6 w-16 rounded-full" /></td>
+      <td className="py-4 px-4"><Skeleton className="h-4 w-20" /></td>
+      <td className="py-4 px-4"><Skeleton className="h-6 w-14 rounded-full" /></td>
+      <td className="py-4 px-4"><Skeleton className="h-6 w-20 rounded-full" /></td>
+      <td className="py-4 px-4">
+        <div className="flex justify-end gap-2">
+          <Skeleton className="h-8 w-16 rounded-lg" />
+          <Skeleton className="h-8 w-20 rounded-lg" />
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+export function TransactionRowSkeleton() {
+  return (
+    <tr className="border-b border-gray-100">
+      <td className="py-4 px-4"><Skeleton className="h-4 w-24" /></td>
+      <td className="py-4 px-4"><Skeleton className="h-6 w-16 rounded-full" /></td>
+      <td className="py-4 px-4"><Skeleton className="h-4 w-32" /></td>
+      <td className="py-4 px-4"><Skeleton className="h-4 w-20" /></td>
+      <td className="py-4 px-4"><Skeleton className="h-6 w-20 rounded-full" /></td>
+      <td className="py-4 px-4"><Skeleton className="h-8 w-16 rounded-lg ml-auto" /></td>
+    </tr>
+  );
+}
+
+export function MetricCardSkeleton() {
+  return (
+    <div className="rounded-2xl border border-gray-100 bg-white p-6 flex flex-col gap-3">
+      <Skeleton className="h-4 w-36" />
+      <Skeleton className="h-10 w-24" />
+      <Skeleton className="h-3 w-28" />
+    </div>
+  );
+}

--- a/harvest-finance/frontend/src/components/ui/Skeleton/index.ts
+++ b/harvest-finance/frontend/src/components/ui/Skeleton/index.ts
@@ -1,0 +1,1 @@
+export { Skeleton, VaultCardSkeleton, VaultTableRowSkeleton, TransactionRowSkeleton, MetricCardSkeleton } from './Skeleton';

--- a/harvest-finance/frontend/src/components/ui/index.ts
+++ b/harvest-finance/frontend/src/components/ui/index.ts
@@ -83,3 +83,9 @@ export { cn, withPrefix } from './types';
 // ============================================
 
 export { ThemeToggle } from './ThemeToggle';
+
+// ============================================
+// Skeleton Loaders
+// ============================================
+
+export { Skeleton, VaultCardSkeleton, VaultTableRowSkeleton, TransactionRowSkeleton, MetricCardSkeleton } from './Skeleton';


### PR DESCRIPTION
closes #185 
## Summary                                                                                                                                              
  Implements smooth skeleton loading states across the frontend using Framer Motion shimmer animations and Tailwind CSS, resolving issues #185 and #119.  
                                                                                                                                                          
  ## Changes                                                                                                                                              
                                                                                                                                                          
  ### New: `src/components/ui/Skeleton/`                                                                                                                  
  - `Skeleton` — base component with Framer Motion opacity shimmer (`0.4 → 1 → 0.4`, infinite)                                                            
  - `VaultCardSkeleton` — matches VaultCard layout (icon, name, APY badge, TVL/balance grid, action buttons)                                              
  - `VaultTableRowSkeleton` — matches VaultTable row (6 columns)                                                                                          
  - `TransactionRowSkeleton` — matches transaction table row (6 columns)                                                                                  
  - `MetricCardSkeleton` — matches dashboard metric cards (label + value + helper)                                                                        
  - Exported from `src/components/ui/index.ts`                                                                                                            
                                                                                                                                                          
  ### Modified files                                                                                                                                      
  | File | Change |                                                                                                                                       
  |------|--------|                                                                                                                                       
  | `src/app/vaults/page.tsx` | Added `isLoading` state with 1s timeout; renders skeleton grid/list while loading |                                       
  | `src/app/dashboard/page.tsx` | Shows `MetricCardSkeleton × 4` while `isSyncing` is true |                                                             
  | `src/components/portfolio/TransactionTable.tsx` | Added optional `isLoading` prop; renders 5 skeleton rows when true |                                
  | `src/app/transactions/page.tsx` | Added `isLoading` state with 1s timeout; renders skeleton rows in table |                                           
                                                                                                                                                          
  ## Technical notes                                                                                                                                      
  - No new dependencies — uses `framer-motion` (already installed) and Tailwind utility classes only                                                      
  - Skeletons match exact grid/flex layout of real components to prevent layout shift on load                                                             
  - No test files were modified                                                                                                                           
                                                


- Create reusable Skeleton component with Framer Motion shimmer animation
- Add VaultCardSkeleton, VaultTableRowSkeleton, TransactionRowSkeleton, MetricCardSkeleton variants
- Apply skeletons to vaults/page.tsx (grid + list view)
- Apply skeletons to dashboard/page.tsx (metric cards while isSyncing)
- Add isLoading prop to TransactionTable component
- Apply skeletons to transactions/page.tsx inline table