### PR TITLE
feat(backend): portfolio aggregation, Soroban indexer, paginated Stellar history, Swagger docs

### DIFF
--- a/harvest-finance/backend/.env.example
+++ b/harvest-finance/backend/.env.example
@@ -32,3 +32,16 @@ GPS_VALIDATION_RADIUS_METERS=100
 
 # Payment Configuration
 PAYMENT_AUTO_RELEASE=true
+
+# Stellar Network
+STELLAR_NETWORK=testnet
+STELLAR_PLATFORM_PUBLIC_KEY=
+STELLAR_PLATFORM_SECRET_KEY=
+
+# Soroban Event Indexer
+SOROBAN_INDEXER_ENABLED=false
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+SOROBAN_INDEXER_PAGE_SIZE=100
+SOROBAN_INDEXER_BOOTSTRAP_LEDGERS=120
+# Optional: comma-separated list of contract IDs to filter; leave empty for all.
+SOROBAN_INDEXER_CONTRACT_IDS=

--- a/harvest-finance/backend/src/app.module.ts
+++ b/harvest-finance/backend/src/app.module.ts
@@ -23,7 +23,10 @@ import { HealthModule } from './health/health.module';
 import { LoggerMiddleware } from './logger/logger.middleware';
 import { LoggerModule } from './logger/logger.module';
 import { OrdersModule } from './orders/orders.module';
+import { PortfolioModule } from './portfolio/portfolio.module';
 import { RealtimeModule } from './realtime/realtime.module';
+import { SorobanModule } from './soroban/soroban.module';
+import { StellarModule } from './stellar/stellar.module';
 import { VerificationModule } from './verification/verification.module';
 import {
   Achievement,
@@ -33,6 +36,7 @@ import {
   Notification,
   Order,
   Reward,
+  SorobanEvent,
   Transaction,
   User,
   Vault,
@@ -51,6 +55,7 @@ import { CreateWithdrawals1700000000007 } from './database/migrations/1700000000
 import { CreateFarmVaults1700000000008 } from './database/migrations/1700000000008-CreateFarmVaults';
 import { CreateInsurance1700000000009 } from './database/migrations/1700000000009-CreateInsurance';
 import { AddInsuranceNotificationType1700000000010 } from './database/migrations/1700000000010-AddInsuranceNotificationType';
+import { CreateSorobanEvents1700000000011 } from './database/migrations/1700000000011-CreateSorobanEvents';
 
 @Module({
   imports: [
@@ -82,6 +87,7 @@ import { AddInsuranceNotificationType1700000000010 } from './database/migrations
           FarmVault,
           InsurancePlan,
           InsuranceSubscription,
+          SorobanEvent,
         ],
         migrations: [
           CreateInitialSchema1700000000000,
@@ -92,6 +98,7 @@ import { AddInsuranceNotificationType1700000000010 } from './database/migrations
           CreateFarmVaults1700000000008,
           CreateInsurance1700000000009,
           AddInsuranceNotificationType1700000000010,
+          CreateSorobanEvents1700000000011,
         ],
         synchronize: false,
         migrationsRun: false,
@@ -118,6 +125,9 @@ import { AddInsuranceNotificationType1700000000010 } from './database/migrations
     InsuranceModule,
     RealtimeModule,
     LoggerModule,
+    StellarModule,
+    SorobanModule,
+    PortfolioModule,
   ],
   controllers: [AppController],
   providers: [

--- a/harvest-finance/backend/src/database/entities/index.ts
+++ b/harvest-finance/backend/src/database/entities/index.ts
@@ -9,6 +9,7 @@ export { InsuranceSubscription, SubscriptionStatus } from './insurance-subscript
 export { Notification, NotificationType } from './notification.entity';
 export { Order, OrderStatus } from './order.entity';
 export { Reward, RewardStatus } from './reward.entity';
+export { SorobanEvent, SorobanEventType } from './soroban-event.entity';
 export { Transaction, TransactionStatus, TransactionType } from './transaction.entity';
 export { User, UserRole } from './user.entity';
 export { Vault, VaultStatus, VaultType } from './vault.entity';

--- a/harvest-finance/backend/src/database/entities/soroban-event.entity.ts
+++ b/harvest-finance/backend/src/database/entities/soroban-event.entity.ts
@@ -1,0 +1,61 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+export enum SorobanEventType {
+  CONTRACT = 'contract',
+  SYSTEM = 'system',
+  DIAGNOSTIC = 'diagnostic',
+}
+
+@Entity('soroban_events')
+@Index('idx_soroban_events_contract', ['contractId'])
+@Index('idx_soroban_events_ledger', ['ledger'])
+@Index('idx_soroban_events_event_id', ['eventId'], { unique: true })
+@Index('idx_soroban_events_tx', ['transactionHash'])
+export class SorobanEvent {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'event_id', type: 'varchar', length: 128 })
+  eventId: string;
+
+  @Column({
+    name: 'type',
+    type: 'enum',
+    enum: SorobanEventType,
+    default: SorobanEventType.CONTRACT,
+  })
+  type: SorobanEventType;
+
+  @Column({ name: 'contract_id', type: 'varchar', length: 128, nullable: true })
+  contractId: string | null;
+
+  @Column({ name: 'ledger', type: 'bigint' })
+  ledger: number;
+
+  @Column({ name: 'ledger_closed_at', type: 'timestamp with time zone' })
+  ledgerClosedAt: Date;
+
+  @Column({ name: 'transaction_hash', type: 'varchar', length: 128, nullable: true })
+  transactionHash: string | null;
+
+  @Column({ name: 'paging_token', type: 'varchar', length: 128 })
+  pagingToken: string;
+
+  @Column({ name: 'topics', type: 'jsonb', default: () => "'[]'" })
+  topics: string[];
+
+  @Column({ name: 'value', type: 'jsonb', nullable: true })
+  value: unknown;
+
+  @Column({ name: 'in_successful_contract_call', type: 'boolean', default: true })
+  inSuccessfulContractCall: boolean;
+
+  @CreateDateColumn({ name: 'indexed_at' })
+  indexedAt: Date;
+}

--- a/harvest-finance/backend/src/database/migrations/1700000000011-CreateSorobanEvents.ts
+++ b/harvest-finance/backend/src/database/migrations/1700000000011-CreateSorobanEvents.ts
@@ -1,0 +1,108 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateSorobanEvents1700000000011 implements MigrationInterface {
+  name = 'CreateSorobanEvents1700000000011';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DO $$ BEGIN
+         IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'soroban_events_type_enum') THEN
+           CREATE TYPE "soroban_events_type_enum" AS ENUM ('contract', 'system', 'diagnostic');
+         END IF;
+       END $$;`,
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'soroban_events',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'event_id',
+            type: 'varchar',
+            length: '128',
+            isNullable: false,
+          },
+          {
+            name: 'type',
+            type: 'soroban_events_type_enum',
+            default: "'contract'",
+          },
+          {
+            name: 'contract_id',
+            type: 'varchar',
+            length: '128',
+            isNullable: true,
+          },
+          {
+            name: 'ledger',
+            type: 'bigint',
+            isNullable: false,
+          },
+          {
+            name: 'ledger_closed_at',
+            type: 'timestamp with time zone',
+            isNullable: false,
+          },
+          {
+            name: 'transaction_hash',
+            type: 'varchar',
+            length: '128',
+            isNullable: true,
+          },
+          {
+            name: 'paging_token',
+            type: 'varchar',
+            length: '128',
+            isNullable: false,
+          },
+          {
+            name: 'topics',
+            type: 'jsonb',
+            default: "'[]'",
+          },
+          {
+            name: 'value',
+            type: 'jsonb',
+            isNullable: true,
+          },
+          {
+            name: 'in_successful_contract_call',
+            type: 'boolean',
+            default: true,
+          },
+          {
+            name: 'indexed_at',
+            type: 'timestamp with time zone',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "idx_soroban_events_event_id" ON "soroban_events" ("event_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_soroban_events_contract" ON "soroban_events" ("contract_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_soroban_events_ledger" ON "soroban_events" ("ledger")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_soroban_events_tx" ON "soroban_events" ("transaction_hash")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('soroban_events');
+    await queryRunner.query(`DROP TYPE IF EXISTS "soroban_events_type_enum"`);
+  }
+}

--- a/harvest-finance/backend/src/main.ts
+++ b/harvest-finance/backend/src/main.ts
@@ -34,22 +34,31 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle('Harvest Finance API')
     .setDescription(
-      'Harvest Finance - Agricultural Marketplace API\n\n' +
-        '## Features\n' +
-        '- JWT Authentication with RBAC\n' +
-        '- User roles: FARMER, BUYER, INSPECTOR, ADMIN\n' +
-        '- Secure login and registration\n' +
-        '- Token refresh and logout\n' +
-        '- Password reset functionality\n' +
-        '- Rate limiting\n' +
-        '- Delivery verification with GPS coordinates\n' +
-        '- IPFS image storage for proof of delivery\n' +
-        '- Multi-signature approval workflow\n' +
-        '- Automatic payment release on verification\n' +
-        '- Real-time notifications\n' +
-        '- Inspector assignment management',
+      'Harvest Finance — public API for third-party developers building on top of our vaults.\n\n' +
+        '## Getting started\n' +
+        '1. Create a developer account and obtain a JWT via `POST /auth/login`.\n' +
+        '2. Send the token as `Authorization: Bearer <token>` on every authenticated request.\n' +
+        '3. Explore the modules below; responses are JSON and paginated where applicable.\n\n' +
+        '## Modules\n' +
+        '- **Authentication** — login, refresh, password reset, RBAC.\n' +
+        '- **Vaults** — deposit, withdraw and inspect yield vaults.\n' +
+        '- **Portfolio** — aggregate balances across multiple Stellar accounts and vaults.\n' +
+        '- **Stellar** — escrow, multi-sig, paginated transaction history on Stellar.\n' +
+        '- **Soroban Events** — indexed ContractEvents for building real-time dashboards.\n' +
+        '- **Orders / Verifications / Deliveries** — agricultural marketplace workflows.\n\n' +
+        '## Conventions\n' +
+        '- Collections expose `skip` / `limit` query parameters (limit is capped at 200).\n' +
+        '- Monetary fields use 7-decimal strings to match Stellar precision.\n' +
+        '- All timestamps are ISO 8601 UTC.\n',
     )
     .setVersion('1.0')
+    .setContact(
+      'Harvest Finance',
+      'https://github.com/code-flexing/Harvest-Finance',
+      'dev@harvest.finance',
+    )
+    .setLicense('MIT', 'https://opensource.org/licenses/MIT')
+    .addServer('http://localhost:5000', 'Local development')
     .addBearerAuth(
       {
         type: 'http',
@@ -62,13 +71,24 @@ async function bootstrap() {
       'JWT-auth',
     )
     .addTag('Authentication', 'Authentication endpoints')
+    .addTag('Vaults', 'Vault deposits, withdrawals and lookups')
+    .addTag('Portfolio', 'Aggregated balance reporting across Stellar accounts and vaults')
+    .addTag('Stellar', 'Stellar account, escrow and paginated transaction history endpoints')
+    .addTag('Soroban Events', 'Queryable Soroban ContractEvent index')
     .addTag('verifications', 'Delivery verification endpoints')
     .addTag('deliveries', 'Delivery management endpoints')
     .addTag('orders', 'Order management endpoints')
     .addTag('health', 'Health check endpoints')
     .build();
   const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api/docs', app, document);
+  SwaggerModule.setup('api/docs', app, document, {
+    swaggerOptions: {
+      persistAuthorization: true,
+      docExpansion: 'list',
+      filter: true,
+    },
+    customSiteTitle: 'Harvest Finance API Docs',
+  });
 
   const configService = app.get(ConfigService);
   const port = configService.get<number>('PORT') || 5000;

--- a/harvest-finance/backend/src/portfolio/dto/portfolio.dto.ts
+++ b/harvest-finance/backend/src/portfolio/dto/portfolio.dto.ts
@@ -1,0 +1,91 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  ArrayMaxSize,
+  ArrayNotEmpty,
+  IsArray,
+  IsOptional,
+  IsString,
+  Length,
+} from 'class-validator';
+
+export class AggregatePortfolioDto {
+  @ApiProperty({
+    description: 'Stellar public keys (G-addresses) to aggregate balances for',
+    example: [
+      'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWX',
+    ],
+    type: [String],
+    maxItems: 20,
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayMaxSize(20)
+  @IsString({ each: true })
+  @Length(56, 56, { each: true })
+  stellarAddresses: string[];
+}
+
+export class AssetBalanceDto {
+  @ApiProperty({ example: 'XLM', description: 'Asset code' })
+  assetCode: string;
+
+  @ApiPropertyOptional({
+    example: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWX',
+    description: 'Asset issuer (null for native XLM)',
+  })
+  assetIssuer: string | null;
+
+  @ApiProperty({ example: '1234.5670000', description: 'Total balance across all accounts' })
+  balance: string;
+}
+
+export class StellarAccountSnapshotDto {
+  @ApiProperty({ description: 'Stellar public key' })
+  publicKey: string;
+
+  @ApiProperty({ example: true, description: 'Whether the account was found on-chain' })
+  exists: boolean;
+
+  @ApiProperty({ type: [AssetBalanceDto], description: 'Per-asset balances for this account' })
+  balances: AssetBalanceDto[];
+
+  @ApiPropertyOptional({
+    example: 'Account not found',
+    description: 'Present only if an error occurred while loading this account',
+  })
+  error?: string;
+}
+
+export class VaultHoldingDto {
+  @ApiProperty({ description: 'Vault ID' })
+  vaultId: string;
+
+  @ApiProperty({ example: 'My Crop Production Vault', description: 'Vault name' })
+  vaultName: string;
+
+  @ApiProperty({ example: 'CROP_PRODUCTION', description: 'Vault type' })
+  vaultType: string;
+
+  @ApiProperty({ example: 1000.5, description: 'User balance held in this vault' })
+  balance: number;
+}
+
+export class PortfolioResponseDto {
+  @ApiProperty({ description: 'User ID the portfolio belongs to' })
+  userId: string;
+
+  @ApiProperty({ example: '2026-04-24T12:00:00.000Z', description: 'ISO timestamp of the aggregation' })
+  generatedAt: string;
+
+  @ApiProperty({ type: [StellarAccountSnapshotDto], description: 'Per-account breakdown' })
+  accounts: StellarAccountSnapshotDto[];
+
+  @ApiProperty({ type: [AssetBalanceDto], description: 'Aggregated on-chain balances across all accounts' })
+  aggregatedStellarBalances: AssetBalanceDto[];
+
+  @ApiProperty({ type: [VaultHoldingDto], description: 'User holdings per vault' })
+  vaults: VaultHoldingDto[];
+
+  @ApiProperty({ example: 5000.75, description: 'Sum of confirmed deposits across all vaults' })
+  totalVaultBalance: number;
+}

--- a/harvest-finance/backend/src/portfolio/portfolio.controller.ts
+++ b/harvest-finance/backend/src/portfolio/portfolio.controller.ts
@@ -1,0 +1,89 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Query,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import {
+  AggregatePortfolioDto,
+  PortfolioResponseDto,
+} from './dto/portfolio.dto';
+import { PortfolioService } from './portfolio.service';
+
+@ApiTags('Portfolio')
+@ApiBearerAuth('JWT-auth')
+@Controller('api/v1/portfolio')
+@UseGuards(JwtAuthGuard)
+export class PortfolioController {
+  constructor(private readonly portfolioService: PortfolioService) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Aggregate a user portfolio across Stellar accounts and vaults',
+    description:
+      "Calculates the authenticated user's balance across multiple Stellar accounts and all vault holdings. " +
+      'Provide a comma-separated list of Stellar public keys via the `addresses` query parameter. ' +
+      "If omitted, only the user's stored stellar address and vault holdings are used.",
+  })
+  @ApiQuery({
+    name: 'addresses',
+    required: false,
+    type: String,
+    description: 'Comma-separated list of Stellar G-addresses',
+    example: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWX',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Aggregated portfolio',
+    type: PortfolioResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized - Invalid or missing token' })
+  async getPortfolio(
+    @Request() req: any,
+    @Query('addresses') addresses?: string,
+  ): Promise<PortfolioResponseDto> {
+    const parsed = (addresses ?? '')
+      .split(',')
+      .map((a) => a.trim())
+      .filter(Boolean);
+    return this.portfolioService.buildPortfolio(req.user.id, parsed);
+  }
+
+  @Post('aggregate')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Aggregate a portfolio across an explicit list of Stellar accounts',
+    description:
+      "Same as GET /portfolio but accepts a validated JSON body listing the Stellar public keys to aggregate. " +
+      'Useful for clients holding custody across many accounts.',
+  })
+  @ApiBody({ type: AggregatePortfolioDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Aggregated portfolio',
+    type: PortfolioResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Validation failed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized - Invalid or missing token' })
+  async aggregatePortfolio(
+    @Request() req: any,
+    @Body() dto: AggregatePortfolioDto,
+  ): Promise<PortfolioResponseDto> {
+    return this.portfolioService.buildPortfolio(req.user.id, dto.stellarAddresses);
+  }
+}

--- a/harvest-finance/backend/src/portfolio/portfolio.module.ts
+++ b/harvest-finance/backend/src/portfolio/portfolio.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Deposit } from '../database/entities/deposit.entity';
+import { Vault } from '../database/entities/vault.entity';
+import { User } from '../database/entities/user.entity';
+import { AuthModule } from '../auth/auth.module';
+import { StellarModule } from '../stellar/stellar.module';
+import { PortfolioController } from './portfolio.controller';
+import { PortfolioService } from './portfolio.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Deposit, Vault, User]),
+    StellarModule,
+    AuthModule,
+  ],
+  controllers: [PortfolioController],
+  providers: [PortfolioService],
+  exports: [PortfolioService],
+})
+export class PortfolioModule {}

--- a/harvest-finance/backend/src/portfolio/portfolio.service.ts
+++ b/harvest-finance/backend/src/portfolio/portfolio.service.ts
@@ -1,0 +1,149 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import * as StellarSdk from 'stellar-sdk';
+import { StellarService } from '../stellar/services/stellar.service';
+import { Deposit, DepositStatus } from '../database/entities/deposit.entity';
+import { Vault } from '../database/entities/vault.entity';
+import { User } from '../database/entities/user.entity';
+import {
+  AssetBalanceDto,
+  PortfolioResponseDto,
+  StellarAccountSnapshotDto,
+  VaultHoldingDto,
+} from './dto/portfolio.dto';
+
+@Injectable()
+export class PortfolioService {
+  private readonly logger = new Logger(PortfolioService.name);
+
+  constructor(
+    private readonly stellarService: StellarService,
+    @InjectRepository(Deposit)
+    private readonly depositRepository: Repository<Deposit>,
+    @InjectRepository(Vault)
+    private readonly vaultRepository: Repository<Vault>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  async buildPortfolio(
+    userId: string,
+    stellarAddresses: string[],
+  ): Promise<PortfolioResponseDto> {
+    const uniqueAddresses = Array.from(
+      new Set((stellarAddresses ?? []).filter(Boolean)),
+    );
+
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+    if (user?.stellarAddress && !uniqueAddresses.includes(user.stellarAddress)) {
+      uniqueAddresses.push(user.stellarAddress);
+    }
+
+    const accountSnapshots = await Promise.all(
+      uniqueAddresses.map((addr) => this.snapshotAccount(addr)),
+    );
+
+    const aggregatedStellarBalances = this.aggregate(accountSnapshots);
+
+    const { vaults, totalVaultBalance } = await this.getVaultHoldings(userId);
+
+    return {
+      userId,
+      generatedAt: new Date().toISOString(),
+      accounts: accountSnapshots,
+      aggregatedStellarBalances,
+      vaults,
+      totalVaultBalance,
+    };
+  }
+
+  private async snapshotAccount(
+    publicKey: string,
+  ): Promise<StellarAccountSnapshotDto> {
+    if (!StellarSdk.StrKey.isValidEd25519PublicKey(publicKey)) {
+      return {
+        publicKey,
+        exists: false,
+        balances: [],
+        error: 'Invalid Stellar public key',
+      };
+    }
+
+    try {
+      const balances = await this.stellarService.getAccountBalances(publicKey);
+      return { publicKey, exists: true, balances };
+    } catch (err: any) {
+      this.logger.warn(
+        `Failed to load Stellar account ${publicKey}: ${err?.message ?? 'unknown'}`,
+      );
+      return {
+        publicKey,
+        exists: false,
+        balances: [],
+        error: err?.response?.status === 404 ? 'Account not found' : 'Account load failed',
+      };
+    }
+  }
+
+  private aggregate(
+    accounts: StellarAccountSnapshotDto[],
+  ): AssetBalanceDto[] {
+    const totals = new Map<string, AssetBalanceDto>();
+
+    for (const account of accounts) {
+      for (const bal of account.balances) {
+        const key = `${bal.assetCode}:${bal.assetIssuer ?? ''}`;
+        const existing = totals.get(key);
+        const current = Number(bal.balance) || 0;
+        if (existing) {
+          existing.balance = (Number(existing.balance) + current).toFixed(7);
+        } else {
+          totals.set(key, {
+            assetCode: bal.assetCode,
+            assetIssuer: bal.assetIssuer,
+            balance: current.toFixed(7),
+          });
+        }
+      }
+    }
+
+    return Array.from(totals.values());
+  }
+
+  private async getVaultHoldings(
+    userId: string,
+  ): Promise<{ vaults: VaultHoldingDto[]; totalVaultBalance: number }> {
+    const rows = await this.depositRepository
+      .createQueryBuilder('deposit')
+      .select('deposit.vaultId', 'vaultId')
+      .addSelect('SUM(deposit.amount)', 'balance')
+      .where('deposit.userId = :userId', { userId })
+      .andWhere('deposit.status = :status', { status: DepositStatus.CONFIRMED })
+      .groupBy('deposit.vaultId')
+      .getRawMany<{ vaultId: string; balance: string }>();
+
+    if (rows.length === 0) {
+      return { vaults: [], totalVaultBalance: 0 };
+    }
+
+    const vaultIds = rows.map((r) => r.vaultId);
+    const vaults = await this.vaultRepository.find({ where: { id: In(vaultIds) } });
+    const vaultMap = new Map(vaults.map((v) => [v.id, v]));
+
+    let total = 0;
+    const vaultHoldings: VaultHoldingDto[] = rows.map((row) => {
+      const vault = vaultMap.get(row.vaultId);
+      const balance = parseFloat(row.balance) || 0;
+      total += balance;
+      return {
+        vaultId: row.vaultId,
+        vaultName: vault?.vaultName ?? 'Unknown Vault',
+        vaultType: vault?.type ?? 'UNKNOWN',
+        balance,
+      };
+    });
+
+    return { vaults: vaultHoldings, totalVaultBalance: total };
+  }
+}

--- a/harvest-finance/backend/src/soroban/dto/soroban-events.dto.ts
+++ b/harvest-finance/backend/src/soroban/dto/soroban-events.dto.ts
@@ -1,0 +1,107 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Length,
+  Max,
+  Min,
+} from 'class-validator';
+import { SorobanEventType } from '../../database/entities/soroban-event.entity';
+
+export class QuerySorobanEventsDto {
+  @ApiPropertyOptional({
+    description: 'Filter by contract ID (C-address)',
+    example: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  })
+  @IsOptional()
+  @IsString()
+  @Length(1, 128)
+  contractId?: string;
+
+  @ApiPropertyOptional({ enum: SorobanEventType, description: 'Filter by event type' })
+  @IsOptional()
+  @IsEnum(SorobanEventType)
+  type?: SorobanEventType;
+
+  @ApiPropertyOptional({ description: 'Minimum ledger sequence (inclusive)', example: 100000 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  fromLedger?: number;
+
+  @ApiPropertyOptional({ description: 'Maximum ledger sequence (inclusive)', example: 200000 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  toLedger?: number;
+
+  @ApiPropertyOptional({ description: 'Number of records to skip', example: 0, default: 0 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  skip?: number = 0;
+
+  @ApiPropertyOptional({
+    description: 'Max records to return (1-200)',
+    example: 50,
+    default: 50,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  limit?: number = 50;
+}
+
+export class SorobanEventDto {
+  @ApiProperty() id: string;
+  @ApiProperty() eventId: string;
+  @ApiProperty({ enum: SorobanEventType }) type: SorobanEventType;
+  @ApiProperty({ nullable: true }) contractId: string | null;
+  @ApiProperty() ledger: number;
+  @ApiProperty() ledgerClosedAt: Date;
+  @ApiProperty({ nullable: true }) transactionHash: string | null;
+  @ApiProperty() pagingToken: string;
+  @ApiProperty({ type: [String] }) topics: string[];
+  @ApiProperty({ required: false, nullable: true }) value: unknown;
+  @ApiProperty() inSuccessfulContractCall: boolean;
+  @ApiProperty() indexedAt: Date;
+}
+
+export class SorobanEventPageDto {
+  @ApiProperty({ type: [SorobanEventDto] })
+  items: SorobanEventDto[];
+
+  @ApiProperty({ example: 123 })
+  total: number;
+
+  @ApiProperty({ example: 0 })
+  skip: number;
+
+  @ApiProperty({ example: 50 })
+  limit: number;
+}
+
+export class IndexerStatusDto {
+  @ApiProperty({ example: true, description: 'Whether the indexer is enabled' })
+  enabled: boolean;
+
+  @ApiProperty({ example: 'https://soroban-testnet.stellar.org', description: 'Soroban RPC URL' })
+  rpcUrl: string;
+
+  @ApiProperty({ example: 123456, nullable: true, description: 'Last ledger sequence indexed' })
+  lastLedger: number | null;
+
+  @ApiProperty({ example: 123456, nullable: true, description: 'Total events indexed' })
+  totalEvents: number;
+
+  @ApiProperty({ example: '2026-04-24T12:00:00.000Z', nullable: true, description: 'Last successful poll timestamp' })
+  lastPolledAt: string | null;
+}

--- a/harvest-finance/backend/src/soroban/soroban-indexer.service.ts
+++ b/harvest-finance/backend/src/soroban/soroban-indexer.service.ts
@@ -1,0 +1,241 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Between, FindOptionsWhere, Repository } from 'typeorm';
+import axios, { AxiosInstance } from 'axios';
+import {
+  SorobanEvent,
+  SorobanEventType,
+} from '../database/entities/soroban-event.entity';
+import {
+  QuerySorobanEventsDto,
+  IndexerStatusDto,
+  SorobanEventPageDto,
+} from './dto/soroban-events.dto';
+
+interface RpcContractEvent {
+  id: string;
+  type: 'contract' | 'system' | 'diagnostic';
+  ledger: number;
+  ledgerClosedAt: string;
+  contractId?: string;
+  pagingToken: string;
+  topic?: string[];
+  value?: unknown;
+  inSuccessfulContractCall?: boolean;
+  txHash?: string;
+}
+
+interface RpcGetEventsResponse {
+  events: RpcContractEvent[];
+  latestLedger: number;
+}
+
+@Injectable()
+export class SorobanIndexerService implements OnModuleInit {
+  private readonly logger = new Logger(SorobanIndexerService.name);
+  private readonly enabled: boolean;
+  private readonly rpcUrl: string;
+  private readonly pageSize: number;
+  private readonly filterContractIds: string[];
+  private readonly http: AxiosInstance;
+
+  private lastIndexedLedger: number | null = null;
+  private lastPolledAt: Date | null = null;
+  private running = false;
+
+  constructor(
+    @InjectRepository(SorobanEvent)
+    private readonly eventRepository: Repository<SorobanEvent>,
+    private readonly config: ConfigService,
+  ) {
+    this.enabled = this.config.get<string>('SOROBAN_INDEXER_ENABLED', 'false') === 'true';
+    const network = this.config.get<string>('STELLAR_NETWORK', 'testnet');
+    const defaultUrl =
+      network === 'mainnet'
+        ? 'https://soroban-rpc.mainnet.stellar.gateway.fm'
+        : 'https://soroban-testnet.stellar.org';
+    this.rpcUrl = this.config.get<string>('SOROBAN_RPC_URL', defaultUrl);
+    this.pageSize = Math.min(
+      Math.max(parseInt(this.config.get<string>('SOROBAN_INDEXER_PAGE_SIZE', '100'), 10), 1),
+      1000,
+    );
+    const ids = this.config.get<string>('SOROBAN_INDEXER_CONTRACT_IDS', '').trim();
+    this.filterContractIds = ids ? ids.split(',').map((s) => s.trim()).filter(Boolean) : [];
+
+    this.http = axios.create({
+      baseURL: this.rpcUrl,
+      timeout: 15_000,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  async onModuleInit(): Promise<void> {
+    try {
+      const latest = await this.eventRepository
+        .createQueryBuilder('e')
+        .select('MAX(e.ledger)', 'maxLedger')
+        .getRawOne<{ maxLedger: string | null }>();
+      this.lastIndexedLedger = latest?.maxLedger ? parseInt(latest.maxLedger, 10) : null;
+      this.logger.log(
+        `Soroban indexer initialised | enabled=${this.enabled} rpc=${this.rpcUrl} lastLedger=${this.lastIndexedLedger ?? 'none'}`,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Failed to resolve last indexed ledger (table may not yet exist): ${(err as Error).message}`,
+      );
+    }
+  }
+
+  /**
+   * Polls the Soroban RPC for new ContractEvents and persists them.
+   * Runs every 30s while `SOROBAN_INDEXER_ENABLED=true`.
+   */
+  @Cron(CronExpression.EVERY_30_SECONDS)
+  async pollEvents(): Promise<void> {
+    if (!this.enabled || this.running) return;
+    this.running = true;
+    try {
+      const result = await this.runOnce();
+      if (result.saved > 0) {
+        this.logger.log(
+          `Indexed ${result.saved} Soroban events (lastLedger=${this.lastIndexedLedger}, latest=${result.latestLedger})`,
+        );
+      }
+    } catch (err) {
+      this.logger.error(
+        `Soroban indexer poll failed: ${(err as Error).message}`,
+        (err as Error).stack,
+      );
+    } finally {
+      this.lastPolledAt = new Date();
+      this.running = false;
+    }
+  }
+
+  /**
+   * Executes a single poll iteration. Exposed for tests and manual triggers.
+   */
+  async runOnce(): Promise<{ saved: number; latestLedger: number | null }> {
+    const startLedger = await this.resolveStartLedger();
+    const response = await this.fetchEvents(startLedger);
+
+    if (!response.events.length) {
+      return { saved: 0, latestLedger: response.latestLedger };
+    }
+
+    const entities = response.events.map((ev) => this.toEntity(ev));
+    const saved = await this.persist(entities);
+    const maxLedgerInBatch = entities.reduce(
+      (max, e) => (e.ledger > max ? e.ledger : max),
+      this.lastIndexedLedger ?? 0,
+    );
+    this.lastIndexedLedger = maxLedgerInBatch;
+
+    return { saved, latestLedger: response.latestLedger };
+  }
+
+  private async resolveStartLedger(): Promise<number> {
+    if (this.lastIndexedLedger && this.lastIndexedLedger > 0) {
+      return this.lastIndexedLedger + 1;
+    }
+
+    // Bootstrap from getLatestLedger - N so we don't attempt to replay history.
+    try {
+      const latest = await this.rpcCall<{ sequence: number }>('getLatestLedger', {});
+      const backoff = parseInt(this.config.get<string>('SOROBAN_INDEXER_BOOTSTRAP_LEDGERS', '120'), 10);
+      return Math.max(latest.sequence - backoff, 1);
+    } catch {
+      return 1;
+    }
+  }
+
+  private async fetchEvents(startLedger: number): Promise<RpcGetEventsResponse> {
+    const filters: Record<string, unknown> = { type: 'contract' };
+    if (this.filterContractIds.length > 0) {
+      filters.contractIds = this.filterContractIds;
+    }
+
+    return this.rpcCall<RpcGetEventsResponse>('getEvents', {
+      startLedger,
+      filters: [filters],
+      pagination: { limit: this.pageSize },
+    });
+  }
+
+  private async rpcCall<T>(method: string, params: unknown): Promise<T> {
+    const { data } = await this.http.post('', {
+      jsonrpc: '2.0',
+      id: Date.now(),
+      method,
+      params,
+    });
+    if (data.error) {
+      throw new Error(
+        `Soroban RPC error: ${data.error.code} ${data.error.message ?? 'unknown'}`,
+      );
+    }
+    return data.result as T;
+  }
+
+  private toEntity(ev: RpcContractEvent): SorobanEvent {
+    const entity = new SorobanEvent();
+    entity.eventId = ev.id;
+    entity.type = (ev.type as SorobanEventType) ?? SorobanEventType.CONTRACT;
+    entity.contractId = ev.contractId ?? null;
+    entity.ledger = ev.ledger;
+    entity.ledgerClosedAt = ev.ledgerClosedAt ? new Date(ev.ledgerClosedAt) : new Date();
+    entity.transactionHash = ev.txHash ?? null;
+    entity.pagingToken = ev.pagingToken ?? ev.id;
+    entity.topics = ev.topic ?? [];
+    entity.value = ev.value ?? null;
+    entity.inSuccessfulContractCall = ev.inSuccessfulContractCall ?? true;
+    return entity;
+  }
+
+  private async persist(entities: SorobanEvent[]): Promise<number> {
+    if (entities.length === 0) return 0;
+    // Use upsert on event_id so reprocessing the same RPC window is idempotent.
+    const result = await this.eventRepository
+      .createQueryBuilder()
+      .insert()
+      .into(SorobanEvent)
+      .values(entities)
+      .orIgnore()
+      .execute();
+    return result.identifiers.filter((id) => id !== undefined).length;
+  }
+
+  async query(filter: QuerySorobanEventsDto): Promise<SorobanEventPageDto> {
+    const skip = filter.skip ?? 0;
+    const limit = Math.min(filter.limit ?? 50, 200);
+
+    const where: FindOptionsWhere<SorobanEvent> = {};
+    if (filter.contractId) where.contractId = filter.contractId;
+    if (filter.type) where.type = filter.type;
+    if (filter.fromLedger != null && filter.toLedger != null) {
+      where.ledger = Between(filter.fromLedger, filter.toLedger);
+    }
+
+    const [items, total] = await this.eventRepository.findAndCount({
+      where,
+      skip,
+      take: limit,
+      order: { ledger: 'DESC', pagingToken: 'DESC' },
+    });
+
+    return { items: items as any, total, skip, limit };
+  }
+
+  async status(): Promise<IndexerStatusDto> {
+    const totalEvents = await this.eventRepository.count();
+    return {
+      enabled: this.enabled,
+      rpcUrl: this.rpcUrl,
+      lastLedger: this.lastIndexedLedger,
+      totalEvents,
+      lastPolledAt: this.lastPolledAt ? this.lastPolledAt.toISOString() : null,
+    };
+  }
+}

--- a/harvest-finance/backend/src/soroban/soroban.controller.ts
+++ b/harvest-finance/backend/src/soroban/soroban.controller.ts
@@ -1,0 +1,51 @@
+import {
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import {
+  IndexerStatusDto,
+  QuerySorobanEventsDto,
+  SorobanEventPageDto,
+} from './dto/soroban-events.dto';
+import { SorobanIndexerService } from './soroban-indexer.service';
+
+@ApiTags('Soroban Events')
+@ApiBearerAuth('JWT-auth')
+@Controller('api/v1/soroban/events')
+@UseGuards(JwtAuthGuard)
+export class SorobanController {
+  constructor(private readonly indexer: SorobanIndexerService) {}
+
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Query indexed Soroban contract events',
+    description:
+      'Returns Soroban ContractEvents pulled from the Soroban RPC by the background indexer. ' +
+      'Supports filtering by contract ID, event type, and ledger range, plus skip/limit pagination.',
+  })
+  @ApiResponse({ status: 200, type: SorobanEventPageDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async list(@Query() query: QuerySorobanEventsDto): Promise<SorobanEventPageDto> {
+    return this.indexer.query(query);
+  }
+
+  @Get('status')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Inspect Soroban indexer status' })
+  @ApiResponse({ status: 200, type: IndexerStatusDto })
+  async status(): Promise<IndexerStatusDto> {
+    return this.indexer.status();
+  }
+}

--- a/harvest-finance/backend/src/soroban/soroban.module.ts
+++ b/harvest-finance/backend/src/soroban/soroban.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SorobanEvent } from '../database/entities/soroban-event.entity';
+import { AuthModule } from '../auth/auth.module';
+import { SorobanController } from './soroban.controller';
+import { SorobanIndexerService } from './soroban-indexer.service';
+
+@Module({
+  imports: [
+    ConfigModule,
+    TypeOrmModule.forFeature([SorobanEvent]),
+    AuthModule,
+  ],
+  controllers: [SorobanController],
+  providers: [SorobanIndexerService],
+  exports: [SorobanIndexerService],
+})
+export class SorobanModule {}

--- a/harvest-finance/backend/src/stellar/dto/stellar-history.dto.ts
+++ b/harvest-finance/backend/src/stellar/dto/stellar-history.dto.ts
@@ -1,0 +1,107 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsIn, IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class StellarHistoryQueryDto {
+  @ApiPropertyOptional({
+    description: 'Number of records to skip from the start of the result set',
+    example: 0,
+    default: 0,
+    minimum: 0,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  skip?: number = 0;
+
+  @ApiPropertyOptional({
+    description: 'Maximum number of records to return (capped at 200)',
+    example: 20,
+    default: 20,
+    minimum: 1,
+    maximum: 200,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({
+    description: 'Ordering by ledger sequence',
+    enum: ['asc', 'desc'],
+    default: 'desc',
+  })
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  order?: 'asc' | 'desc' = 'desc';
+}
+
+export class StellarTransactionRecordDto {
+  @ApiProperty({ example: 'fe...abc', description: 'Transaction hash' })
+  hash: string;
+
+  @ApiProperty({ example: 1234567, description: 'Ledger sequence the tx closed in' })
+  ledger: number;
+
+  @ApiProperty({ example: '2026-04-24T12:00:00Z', description: 'Ledger close time' })
+  createdAt: string;
+
+  @ApiProperty({ example: 'GA...XYZ', description: 'Source account' })
+  sourceAccount: string;
+
+  @ApiProperty({ example: '100', description: 'Fee charged in stroops' })
+  feeCharged: string;
+
+  @ApiProperty({ example: 1, description: 'Number of operations in the tx' })
+  operationCount: number;
+
+  @ApiProperty({ example: true, description: 'Whether the transaction succeeded' })
+  successful: boolean;
+
+  @ApiProperty({ example: 'HF-escrow:123', nullable: true, description: 'Memo value if any' })
+  memo: string | null;
+
+  @ApiProperty({ example: 'text', nullable: true, description: 'Memo type if any' })
+  memoType: string | null;
+
+  @ApiProperty({ example: '1234567-1', description: 'Horizon paging token' })
+  pagingToken: string;
+}
+
+export class StellarHistoryPageDto {
+  @ApiProperty({ type: [StellarTransactionRecordDto] })
+  records: StellarTransactionRecordDto[];
+
+  @ApiProperty({ example: 0, description: 'Records skipped' })
+  skip: number;
+
+  @ApiProperty({ example: 20, description: 'Page size used' })
+  limit: number;
+
+  @ApiProperty({ enum: ['asc', 'desc'], example: 'desc' })
+  order: 'asc' | 'desc';
+
+  @ApiProperty({
+    example: null,
+    nullable: true,
+    description: 'Horizon cursor for the first record in the page (for cursor-based clients)',
+  })
+  prevCursor: string | null;
+
+  @ApiProperty({
+    example: null,
+    nullable: true,
+    description: 'Horizon cursor for the last record in the page (for cursor-based clients)',
+  })
+  nextCursor: string | null;
+
+  @ApiProperty({
+    example: null,
+    nullable: true,
+    description: 'Total record count; Horizon does not provide totals so this is always null',
+  })
+  total: number | null;
+}

--- a/harvest-finance/backend/src/stellar/dto/stellar.dto.ts
+++ b/harvest-finance/backend/src/stellar/dto/stellar.dto.ts
@@ -1,79 +1,97 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsString, IsNumber, IsOptional, IsNotEmpty, Min, Length } from 'class-validator';
 
 export class CreateEscrowDto {
+    @ApiProperty({ example: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWX' })
     @IsString()
     @IsNotEmpty()
     @Length(56, 56)
     farmerPublicKey: string;
 
+    @ApiProperty({ example: 'GBUYER1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGH' })
     @IsString()
     @IsNotEmpty()
     @Length(56, 56)
     buyerPublicKey: string;
 
+    @ApiProperty({ example: '1000.0000000', description: 'Amount as a numeric string' })
     @IsString()
     @IsNotEmpty()
     amount: string;
 
+    @ApiPropertyOptional({ example: 'USDC', description: 'Asset code, defaults to XLM' })
     @IsString()
     @IsOptional()
     assetCode?: string;
 
+    @ApiPropertyOptional({ description: 'Asset issuer, required for non-native assets' })
     @IsString()
     @IsOptional()
     assetIssuer?: string;
 
+    @ApiProperty({ example: 1746057600, description: 'Unix timestamp (seconds) for escrow expiry' })
     @IsNumber()
     @Min(0)
     deadlineUnixTimestamp: number;
 
+    @ApiProperty({ example: 'order-123', description: 'Internal order ID referenced by the memo' })
     @IsString()
     @IsNotEmpty()
     orderId: string;
 }
 
 export class ReleasePaymentDto {
+    @ApiProperty({ description: 'Claimable balance ID returned by createEscrow' })
     @IsString()
     @IsNotEmpty()
     balanceId: string;
 
+    @ApiProperty({ example: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWX' })
     @IsString()
     @IsNotEmpty()
     @Length(56, 56)
     farmerPublicKey: string;
 
+    @ApiProperty({ description: 'Farmer secret key (S-address)' })
     @IsString()
     @IsNotEmpty()
     farmerSecretKey: string;
 }
 
 export class RefundDto {
+    @ApiProperty({ description: 'Claimable balance ID to refund' })
     @IsString()
     @IsNotEmpty()
     balanceId: string;
 
+    @ApiProperty({ example: 'GBUYER1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGH' })
     @IsString()
     @IsNotEmpty()
     @Length(56, 56)
     buyerPublicKey: string;
 
+    @ApiProperty({ description: 'Buyer secret key (S-address)' })
     @IsString()
     @IsNotEmpty()
     buyerSecretKey: string;
 }
 
 export class SetupMultiSigDto {
+    @ApiProperty({ description: 'Primary account public key' })
     @IsString()
     @IsNotEmpty()
     @Length(56, 56)
     primaryPublicKey: string;
 
+    @ApiProperty({ type: [String], description: 'Cosigner public keys' })
     cosignerPublicKeys: string[];
 
+    @ApiProperty({ example: 2, description: 'Signing threshold (1..N)' })
     @IsNumber()
     @Min(1)
     threshold: number;
 
+    @ApiProperty({ description: 'Secret key of the account being configured' })
     @IsString()
     @IsNotEmpty()
     sourceSecretKey: string;

--- a/harvest-finance/backend/src/stellar/services/stellar.service.ts
+++ b/harvest-finance/backend/src/stellar/services/stellar.service.ts
@@ -66,6 +66,140 @@ export class StellarService {
         }
     }
 
+    /**
+     * Returns the full list of asset balances for a Stellar account.
+     * Unlike `getAccountInfo`, this preserves non-native assets so callers
+     * can aggregate portfolios across multiple tokens.
+     */
+    async getAccountBalances(
+        publicKey: string,
+    ): Promise<
+        { assetCode: string; assetIssuer: string | null; balance: string }[]
+    > {
+        this.validatePublicKey(publicKey);
+        try {
+            const account = await this.server.loadAccount(publicKey);
+            return account.balances.map((b: any) => ({
+                assetCode: b.asset_type === 'native' ? 'XLM' : b.asset_code,
+                assetIssuer: b.asset_type === 'native' ? null : b.asset_issuer ?? null,
+                balance: String(b.balance ?? '0'),
+            }));
+        } catch (err) {
+            this.handleStellarError(err, `getAccountBalances(${publicKey})`);
+        }
+    }
+
+    /**
+     * Returns a paginated slice of transactions for a Stellar account.
+     * Wraps Horizon's cursor-based pagination with simple skip/limit semantics
+     * to keep JSON responses bounded.
+     */
+    async getAccountTransactions(
+        publicKey: string,
+        skip = 0,
+        limit = 20,
+        order: 'asc' | 'desc' = 'desc',
+    ): Promise<{
+        total: number | null;
+        skip: number;
+        limit: number;
+        order: 'asc' | 'desc';
+        records: any[];
+        nextCursor: string | null;
+        prevCursor: string | null;
+    }> {
+        this.validatePublicKey(publicKey);
+
+        const safeLimit = Math.min(Math.max(limit, 1), 200);
+        const safeSkip = Math.max(skip, 0);
+
+        try {
+            let remainingToSkip = safeSkip;
+            let cursor: string | undefined;
+            const pageSize = Math.min(200, Math.max(safeLimit, remainingToSkip > 0 ? 200 : safeLimit));
+
+            // Horizon is cursor-paginated; to honour skip we fast-forward through
+            // prior pages using the largest permitted page size.
+            while (remainingToSkip >= pageSize) {
+                const call = this.server
+                    .transactions()
+                    .forAccount(publicKey)
+                    .order(order)
+                    .limit(pageSize);
+                if (cursor) call.cursor(cursor);
+
+                const page = await call.call();
+                if (page.records.length === 0) {
+                    return {
+                        total: null,
+                        skip: safeSkip,
+                        limit: safeLimit,
+                        order,
+                        records: [],
+                        nextCursor: null,
+                        prevCursor: null,
+                    };
+                }
+
+                cursor = page.records[page.records.length - 1].paging_token;
+                remainingToSkip -= page.records.length;
+
+                if (page.records.length < pageSize) {
+                    // Reached the end before finishing the skip.
+                    return {
+                        total: null,
+                        skip: safeSkip,
+                        limit: safeLimit,
+                        order,
+                        records: [],
+                        nextCursor: null,
+                        prevCursor: null,
+                    };
+                }
+            }
+
+            // Consume the remaining skip within the next page, then take the requested slice.
+            const finalPageSize = Math.min(200, remainingToSkip + safeLimit);
+            const finalCall = this.server
+                .transactions()
+                .forAccount(publicKey)
+                .order(order)
+                .limit(finalPageSize);
+            if (cursor) finalCall.cursor(cursor);
+
+            const finalPage = await finalCall.call();
+            const slice = finalPage.records.slice(
+                remainingToSkip,
+                remainingToSkip + safeLimit,
+            );
+
+            const mapped = slice.map((tx: any) => ({
+                hash: tx.hash,
+                ledger: tx.ledger,
+                createdAt: tx.created_at,
+                sourceAccount: tx.source_account,
+                feeCharged: tx.fee_charged,
+                operationCount: tx.operation_count,
+                successful: tx.successful,
+                memo: tx.memo ?? null,
+                memoType: tx.memo_type ?? null,
+                pagingToken: tx.paging_token,
+            }));
+
+            return {
+                total: null,
+                skip: safeSkip,
+                limit: safeLimit,
+                order,
+                records: mapped,
+                nextCursor: slice.length > 0 ? slice[slice.length - 1].paging_token : null,
+                prevCursor: slice.length > 0 ? slice[0].paging_token : null,
+            };
+        } catch (err) {
+            this.handleStellarError(err, `getAccountTransactions(${publicKey})`);
+        }
+    }
+
     async verifyConnection(): Promise<boolean> {
         try {
         await this.server.loadAccount(this.platformPublicKey);

--- a/harvest-finance/backend/src/stellar/stellar.controller.ts
+++ b/harvest-finance/backend/src/stellar/stellar.controller.ts
@@ -8,57 +8,132 @@ import {
     HttpCode,
     HttpStatus,
 } from '@nestjs/common';
+import {
+    ApiBody,
+    ApiOperation,
+    ApiParam,
+    ApiResponse,
+    ApiTags,
+} from '@nestjs/swagger';
 import { StellarService } from './services/stellar.service';
 import { CreateEscrowDto, ReleasePaymentDto, RefundDto, SetupMultiSigDto } from './dto/stellar.dto';
+import {
+    StellarHistoryPageDto,
+    StellarHistoryQueryDto,
+} from './dto/stellar-history.dto';
 
 
+@ApiTags('Stellar')
 @Controller('stellar')
 export class StellarController {
     constructor(private readonly stellarService: StellarService) {}
 
     @Get('health')
+    @ApiOperation({ summary: 'Check the health of the Stellar Horizon connection' })
+    @ApiResponse({
+        status: 200,
+        description: 'Connection status and server timestamp',
+        schema: {
+            example: { connected: true, timestamp: '2026-04-24T12:00:00.000Z' },
+        },
+    })
     async checkHealth() {
         const connected = await this.stellarService.verifyConnection();
         return { connected, timestamp: new Date().toISOString() };
     }
 
     @Get('account/:publicKey')
+    @ApiOperation({ summary: 'Load a Stellar account overview (native balance, signers, thresholds)' })
+    @ApiParam({ name: 'publicKey', description: 'Stellar G-address (56 chars)' })
+    @ApiResponse({ status: 200, description: 'Account info' })
+    @ApiResponse({ status: 400, description: 'Invalid public key or account not found' })
     async getAccount(@Param('publicKey') publicKey: string) {
         return this.stellarService.getAccountInfo(publicKey);
     }
 
+    @Get('account/:publicKey/balances')
+    @ApiOperation({
+        summary: 'List every asset balance for a Stellar account',
+        description: 'Returns native XLM plus all trustline balances; useful for portfolio aggregators.',
+    })
+    @ApiParam({ name: 'publicKey', description: 'Stellar G-address (56 chars)' })
+    @ApiResponse({ status: 200, description: 'Per-asset balances' })
+    async getAccountBalances(@Param('publicKey') publicKey: string) {
+        return this.stellarService.getAccountBalances(publicKey);
+    }
+
+    @Get('account/:publicKey/transactions')
+    @ApiOperation({
+        summary: 'Paginated transaction history for a Stellar account',
+        description:
+            'Returns the account transaction history from Horizon with skip/limit pagination. ' +
+            'Use `limit` (1-200) to bound the response size and `skip` to page through older records.',
+    })
+    @ApiParam({ name: 'publicKey', description: 'Stellar G-address (56 chars)' })
+    @ApiResponse({ status: 200, type: StellarHistoryPageDto })
+    @ApiResponse({ status: 400, description: 'Invalid public key or pagination parameters' })
+    async getAccountTransactions(
+        @Param('publicKey') publicKey: string,
+        @Query() query: StellarHistoryQueryDto,
+    ): Promise<StellarHistoryPageDto> {
+        return this.stellarService.getAccountTransactions(
+            publicKey,
+            query.skip ?? 0,
+            query.limit ?? 20,
+            query.order ?? 'desc',
+        );
+    }
+
     @Get('fee')
+    @ApiOperation({ summary: 'Estimate the current network base fee for N operations' })
+    @ApiResponse({ status: 200, description: 'Fee estimate in XLM and stroops' })
     async estimateFee(@Query('operations') ops?: string) {
         return this.stellarService.estimateFee(ops ? parseInt(ops, 10) : 1);
     }
 
     @Post('escrow')
     @HttpCode(HttpStatus.CREATED)
+    @ApiOperation({ summary: 'Create a claimable-balance escrow for an order' })
+    @ApiBody({ type: CreateEscrowDto })
+    @ApiResponse({ status: 201, description: 'Escrow created' })
+    @ApiResponse({ status: 400, description: 'Validation or Stellar network error' })
     async createEscrow(@Body() dto: CreateEscrowDto) {
         return this.stellarService.createEscrow(dto);
     }
 
     @Post('escrow/release')
+    @ApiOperation({ summary: 'Release escrow funds to the farmer' })
+    @ApiBody({ type: ReleasePaymentDto })
+    @ApiResponse({ status: 200, description: 'Payment released' })
     async releasePayment(@Body() dto: ReleasePaymentDto) {
         return this.stellarService.releasePayment(dto);
     }
 
     @Post('escrow/refund')
+    @ApiOperation({ summary: 'Refund an expired escrow back to the buyer' })
+    @ApiBody({ type: RefundDto })
+    @ApiResponse({ status: 200, description: 'Refund processed' })
     async refundEscrow(@Body() dto: RefundDto) {
         return this.stellarService.refundEscrow(dto);
     }
 
     @Get('escrow/:publicKey')
+    @ApiOperation({ summary: 'List claimable-balance escrows for an account' })
+    @ApiParam({ name: 'publicKey', description: 'Claimant public key' })
     async getEscrows(@Param('publicKey') publicKey: string) {
         return this.stellarService.getClaimableBalances(publicKey);
     }
 
     @Get('transaction/:hash')
+    @ApiOperation({ summary: 'Fetch the status of a Stellar transaction by hash' })
+    @ApiParam({ name: 'hash', description: 'Transaction hash (hex)' })
     async getTransaction(@Param('hash') hash: string) {
         return this.stellarService.getTransactionStatus(hash);
     }
 
     @Post('multisig')
+    @ApiOperation({ summary: 'Configure multi-signature thresholds for a Stellar account' })
+    @ApiBody({ type: SetupMultiSigDto })
     async setupMultiSig(@Body() dto: SetupMultiSigDto) {
         return this.stellarService.setupMultiSigAccount(dto);
     }


### PR DESCRIPTION
## Summary
- Portfolio aggregation API that sums Stellar balances and vault holdings for the authenticated user
- Soroban event indexer: scheduled RPC poller, deduping storage, query + status endpoints
- Paginated Stellar account transaction history with skip/limit/order
- Swagger metadata overhaul for third-party developers (tags, DTO properties, persisted auth)

## Test plan
- [ ] `npm run build`
- [ ] `npm run migration:run` applies `CreateSorobanEvents1700000000011`
- [ ] Hit `/api/docs` and confirm the new Portfolio, Stellar, and Soroban Events sections render
- [ ] `GET /api/v1/portfolio?addresses=<G...>` returns aggregated balances
- [ ] `GET /stellar/account/<G...>/transactions?skip=0&limit=5` returns a bounded page
- [ ] Set `SOROBAN_INDEXER_ENABLED=true` and observe new rows in `soroban_events`

Closes #158
Closes #167
Closes #172
Closes #173
