### PR TITLE
feat(backend): tiered, env-driven throttler config (closes #161)

### DIFF
--- a/harvest-finance/backend/.env.example
+++ b/harvest-finance/backend/.env.example
@@ -18,7 +18,11 @@ JWT_EXPIRES_IN=1h
 JWT_REFRESH_SECRET=super_secret_refresh_jwt_key
 JWT_REFRESH_EXPIRES_IN=7d
 
-# Rate Limiting
+# Rate Limiting (tiered: short = burst, medium = sustained, long = hourly window)
+THROTTLE_SHORT_TTL=1000
+THROTTLE_SHORT_LIMIT=5
+THROTTLE_MEDIUM_TTL=10000
+THROTTLE_MEDIUM_LIMIT=30
 THROTTLE_TTL=60000
 THROTTLE_LIMIT=100
 

--- a/harvest-finance/backend/src/app.module.ts
+++ b/harvest-finance/backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { buildThrottlerOptions } from './common/config/throttler.config';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { VaultsModule } from './vaults/vaults.module';
@@ -60,7 +61,11 @@ import { CreateSorobanEvents1700000000011 } from './database/migrations/17000000
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
-    ThrottlerModule.forRoot([{ ttl: 60000, limit: 100 }]),
+    ThrottlerModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: buildThrottlerOptions,
+    }),
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],
       useFactory: (configService: ConfigService) => ({

--- a/harvest-finance/backend/src/auth/auth.controller.ts
+++ b/harvest-finance/backend/src/auth/auth.controller.ts
@@ -34,7 +34,7 @@ export class AuthController {
    * Register a new user
    */
   @Post('register')
-  @Throttle({ default: { limit: 10, ttl: 60000 } })
+  @Throttle({ long: { limit: 10, ttl: 60000 } })
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({ summary: 'Register a new user' })
   @ApiBody({ type: RegisterDto })
@@ -59,7 +59,7 @@ export class AuthController {
    * Login user
    */
   @Post('login')
-  @Throttle({ default: { limit: 5, ttl: 60000 } })
+  @Throttle({ long: { limit: 5, ttl: 60000 } })
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Login user' })
   @ApiBody({ type: LoginDto })
@@ -121,7 +121,7 @@ export class AuthController {
    * Forgot password
    */
   @Post('forgot-password')
-  @Throttle({ default: { limit: 5, ttl: 60000 } })
+  @Throttle({ long: { limit: 5, ttl: 60000 } })
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Request password reset' })
   @ApiBody({ type: ForgotPasswordDto })
@@ -139,7 +139,7 @@ export class AuthController {
    * Reset password
    */
   @Post('reset-password')
-  @Throttle({ default: { limit: 5, ttl: 60000 } })
+  @Throttle({ long: { limit: 5, ttl: 60000 } })
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Reset password with token' })
   @ApiBody({ type: ResetPasswordDto })

--- a/harvest-finance/backend/src/auth/auth.module.ts
+++ b/harvest-finance/backend/src/auth/auth.module.ts
@@ -2,8 +2,6 @@ import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { ThrottlerModule } from '@nestjs/throttler';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './strategies/jwt.strategy';
@@ -11,38 +9,14 @@ import { User } from '../database/entities/user.entity';
 
 @Module({
   imports: [
-    // TypeORM module for User entity
     TypeOrmModule.forFeature([User]),
-
-    // Passport module
     PassportModule.register({ defaultStrategy: 'jwt' }),
-
-    // JWT module
     JwtModule.register({
       secret: 'super_secret_jwt_key',
       signOptions: {
         expiresIn: '1h',
       },
     }),
-
-    // Throttler module
-    ThrottlerModule.forRoot([
-      {
-        name: 'short',
-        ttl: 1000,
-        limit: 3,
-      },
-      {
-        name: 'medium',
-        ttl: 10000,
-        limit: 20,
-      },
-      {
-        name: 'long',
-        ttl: 900000, // 15 minutes
-        limit: 100,
-      },
-    ]),
   ],
   controllers: [AuthController],
   providers: [AuthService, JwtStrategy],

--- a/harvest-finance/backend/src/common/config/throttler.config.spec.ts
+++ b/harvest-finance/backend/src/common/config/throttler.config.spec.ts
@@ -1,0 +1,58 @@
+import { ConfigService } from '@nestjs/config';
+import { buildThrottlerOptions } from './throttler.config';
+
+const makeConfig = (env: Record<string, string | number | undefined>) =>
+  ({
+    get: <T>(key: string, defaultValue?: T): T => {
+      const value = env[key];
+      return (value === undefined ? defaultValue : value) as T;
+    },
+  }) as unknown as ConfigService;
+
+describe('buildThrottlerOptions', () => {
+  it('exposes short, medium, and long named tiers', () => {
+    const options = buildThrottlerOptions(makeConfig({}));
+    expect(Array.isArray(options)).toBe(true);
+    const names = (options as Array<{ name?: string }>).map(
+      (tier) => tier.name,
+    );
+    expect(names).toEqual(['short', 'medium', 'long']);
+  });
+
+  it('falls back to safe defaults when env vars are unset', () => {
+    const options = buildThrottlerOptions(makeConfig({})) as Array<{
+      name: string;
+      ttl: number;
+      limit: number;
+    }>;
+
+    expect(options[0]).toMatchObject({ name: 'short', ttl: 1000, limit: 5 });
+    expect(options[1]).toMatchObject({
+      name: 'medium',
+      ttl: 10_000,
+      limit: 30,
+    });
+    expect(options[2]).toMatchObject({ name: 'long', ttl: 60_000, limit: 100 });
+  });
+
+  it('honors env-supplied overrides for every tier', () => {
+    const options = buildThrottlerOptions(
+      makeConfig({
+        THROTTLE_SHORT_TTL: 500,
+        THROTTLE_SHORT_LIMIT: 2,
+        THROTTLE_MEDIUM_TTL: 5_000,
+        THROTTLE_MEDIUM_LIMIT: 15,
+        THROTTLE_TTL: 120_000,
+        THROTTLE_LIMIT: 200,
+      }),
+    ) as Array<{ name: string; ttl: number; limit: number }>;
+
+    expect(options[0]).toMatchObject({ name: 'short', ttl: 500, limit: 2 });
+    expect(options[1]).toMatchObject({ name: 'medium', ttl: 5_000, limit: 15 });
+    expect(options[2]).toMatchObject({
+      name: 'long',
+      ttl: 120_000,
+      limit: 200,
+    });
+  });
+});

--- a/harvest-finance/backend/src/common/config/throttler.config.ts
+++ b/harvest-finance/backend/src/common/config/throttler.config.ts
@@ -1,0 +1,22 @@
+import { ConfigService } from '@nestjs/config';
+import { ThrottlerModuleOptions } from '@nestjs/throttler';
+
+export const buildThrottlerOptions = (
+  config: ConfigService,
+): ThrottlerModuleOptions => [
+  {
+    name: 'short',
+    ttl: config.get<number>('THROTTLE_SHORT_TTL', 1000),
+    limit: config.get<number>('THROTTLE_SHORT_LIMIT', 5),
+  },
+  {
+    name: 'medium',
+    ttl: config.get<number>('THROTTLE_MEDIUM_TTL', 10_000),
+    limit: config.get<number>('THROTTLE_MEDIUM_LIMIT', 30),
+  },
+  {
+    name: 'long',
+    ttl: config.get<number>('THROTTLE_TTL', 60_000),
+    limit: config.get<number>('THROTTLE_LIMIT', 100),
+  },
+];

--- a/harvest-finance/backend/src/health/health.controller.ts
+++ b/harvest-finance/backend/src/health/health.controller.ts
@@ -1,6 +1,12 @@
 import { Controller, Get } from '@nestjs/common';
-import { HealthCheck, HealthCheckService, TypeOrmHealthIndicator } from '@nestjs/terminus';
+import {
+  HealthCheck,
+  HealthCheckService,
+  TypeOrmHealthIndicator,
+} from '@nestjs/terminus';
+import { SkipThrottle } from '@nestjs/throttler';
 
+@SkipThrottle()
 @Controller('health')
 export class HealthController {
   constructor(


### PR DESCRIPTION
## Summary
- Promote tiered (`short` / `medium` / `long`) throttler config to `AppModule` via `forRootAsync`, sourced from `THROTTLE_*` env vars with sane defaults.
- Drop the duplicate `ThrottlerModule.forRoot()` in `AuthModule` (calling `forRoot` outside the root was a no-op/conflict; the root module now owns rate-limit config).
- Update `auth.controller`'s `@Throttle` overrides from the legacy `default` key to the named `long` tier — `default` no longer exists once tiers are named.
- Add `@SkipThrottle()` to `HealthController` so liveness/readiness probes aren't rate-limited.
- Document the new env vars in `.env.example`.
- Unit tests for the factory.

Closes #161.

## What changed in behaviour
- Default global limits (when no env vars set):
  - `short`: 5 requests / 1 s
  - `medium`: 30 requests / 10 s
  - `long`: 100 requests / 60 s
- Existing `THROTTLE_TTL` / `THROTTLE_LIMIT` continue to drive the `long` tier (no breaking change for current deployments).
- New (optional): `THROTTLE_SHORT_TTL`, `THROTTLE_SHORT_LIMIT`, `THROTTLE_MEDIUM_TTL`, `THROTTLE_MEDIUM_LIMIT`.
- `/health` is no longer rate-limited.

## Test plan
- [x] `npx jest src/common/config src/auth` — 21 tests passing.
- [x] `npx tsc --noEmit -p tsconfig.json` — clean.
- [ ] Manual: hit `/health` repeatedly, confirm no 429.
- [ ] Manual: set `THROTTLE_SHORT_LIMIT=2`, hammer any endpoint, confirm 429 with the `Too Many Requests` body shape from `ThrottlerExceptionFilter`.

## Out of scope (follow-ups)
- Per-route `@Throttle` decorators on hot polling endpoints (portfolio, realtime, vault reads). Happy to do as a follow-up PR.