### PR TITLE
feat(backend): exponential-backoff retry for Horizon submitTransaction (closes #169)

### DIFF
--- a/harvest-finance/backend/.env.example
+++ b/harvest-finance/backend/.env.example
@@ -38,6 +38,11 @@ STELLAR_NETWORK=testnet
 STELLAR_PLATFORM_PUBLIC_KEY=
 STELLAR_PLATFORM_SECRET_KEY=
 
+# Stellar submitTransaction retry (transient failures only — 5xx, 429, network errors)
+STELLAR_RETRY_MAX_ATTEMPTS=3
+STELLAR_RETRY_BASE_DELAY_MS=500
+STELLAR_RETRY_MAX_DELAY_MS=5000
+
 # Soroban Event Indexer
 SOROBAN_INDEXER_ENABLED=false
 SOROBAN_RPC_URL=https://soroban-testnet.stellar.org

--- a/harvest-finance/backend/src/common/utils/retry.spec.ts
+++ b/harvest-finance/backend/src/common/utils/retry.spec.ts
@@ -1,0 +1,123 @@
+import { retry } from './retry';
+
+const noSleep = () => Promise.resolve();
+
+describe('retry', () => {
+  it('returns the value on the first successful attempt', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const result = await retry(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 10,
+      maxDelayMs: 100,
+      isRetryable: () => true,
+      sleep: noSleep,
+      jitter: false,
+    });
+
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries until the call succeeds', async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('boom-1'))
+      .mockRejectedValueOnce(new Error('boom-2'))
+      .mockResolvedValue('eventually');
+
+    const result = await retry(fn, {
+      maxAttempts: 5,
+      baseDelayMs: 10,
+      maxDelayMs: 100,
+      isRetryable: () => true,
+      sleep: noSleep,
+      jitter: false,
+    });
+
+    expect(result).toBe('eventually');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws after exhausting maxAttempts', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('always'));
+
+    await expect(
+      retry(fn, {
+        maxAttempts: 3,
+        baseDelayMs: 10,
+        maxDelayMs: 100,
+        isRetryable: () => true,
+        sleep: noSleep,
+        jitter: false,
+      }),
+    ).rejects.toThrow('always');
+
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('short-circuits when isRetryable returns false', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('non-retryable'));
+
+    await expect(
+      retry(fn, {
+        maxAttempts: 5,
+        baseDelayMs: 10,
+        maxDelayMs: 100,
+        isRetryable: () => false,
+        sleep: noSleep,
+        jitter: false,
+      }),
+    ).rejects.toThrow('non-retryable');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies exponential backoff capped by maxDelayMs (no jitter)', async () => {
+    const sleeps: number[] = [];
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('a'))
+      .mockRejectedValueOnce(new Error('b'))
+      .mockRejectedValueOnce(new Error('c'))
+      .mockResolvedValue('done');
+
+    const result = await retry(fn, {
+      maxAttempts: 4,
+      baseDelayMs: 100,
+      maxDelayMs: 250,
+      factor: 2,
+      jitter: false,
+      isRetryable: () => true,
+      sleep: (ms) => {
+        sleeps.push(ms);
+        return Promise.resolve();
+      },
+    });
+
+    expect(result).toBe('done');
+    // attempt 1 fails -> sleep 100, attempt 2 fails -> sleep 200,
+    // attempt 3 fails -> sleep capped at 250.
+    expect(sleeps).toEqual([100, 200, 250]);
+  });
+
+  it('invokes onRetry once per backoff', async () => {
+    const onRetry = jest.fn();
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('x'))
+      .mockResolvedValue('ok');
+
+    await retry(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 10,
+      maxDelayMs: 100,
+      isRetryable: () => true,
+      sleep: noSleep,
+      jitter: false,
+      onRetry,
+    });
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledWith(expect.any(Error), 1, 10);
+  });
+});

--- a/harvest-finance/backend/src/common/utils/retry.ts
+++ b/harvest-finance/backend/src/common/utils/retry.ts
@@ -1,0 +1,63 @@
+export interface RetryOptions {
+  /** Total attempts including the first call. Must be >= 1. */
+  maxAttempts: number;
+  /** Initial backoff delay before the second attempt, in milliseconds. */
+  baseDelayMs: number;
+  /** Upper bound on any single backoff delay. */
+  maxDelayMs: number;
+  /** Multiplier applied to the delay after each failure. Defaults to 2. */
+  factor?: number;
+  /** When true (default), each delay is randomised in `[0, computedDelay]`. */
+  jitter?: boolean;
+  /**
+   * Decides whether to retry. Receives the error and the just-completed
+   * attempt number (1-indexed). Return false to give up immediately.
+   */
+  isRetryable: (err: unknown, attempt: number) => boolean;
+  /** Optional hook fired before each backoff sleep. Useful for logging. */
+  onRetry?: (err: unknown, attempt: number, delayMs: number) => void;
+  /** Sleep override; defaults to `setTimeout`. Exposed for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export async function retry<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions,
+): Promise<T> {
+  const factor = options.factor ?? 2;
+  const useJitter = options.jitter ?? true;
+  const sleep = options.sleep ?? defaultSleep;
+
+  let attempt = 0;
+  let lastError: unknown;
+
+  while (attempt < options.maxAttempts) {
+    attempt += 1;
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (
+        attempt >= options.maxAttempts ||
+        !options.isRetryable(err, attempt)
+      ) {
+        throw err;
+      }
+      const exp = Math.min(
+        options.baseDelayMs * Math.pow(factor, attempt - 1),
+        options.maxDelayMs,
+      );
+      const delayMs = useJitter ? Math.floor(Math.random() * exp) : exp;
+      options.onRetry?.(err, attempt, delayMs);
+      await sleep(delayMs);
+    }
+  }
+
+  // Unreachable in practice (the loop either returns or throws), but the
+  // type-checker can't see that. Re-throw the last error so callers don't
+  // receive `undefined`.
+  throw lastError;
+}

--- a/harvest-finance/backend/src/stellar/services/stellar.service.ts
+++ b/harvest-finance/backend/src/stellar/services/stellar.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, Logger, BadRequestException, InternalServerErrorException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as StellarSdk from 'stellar-sdk';
+import { retry } from '../../common/utils/retry';
+import { isRetryableStellarError } from '../utils/stellar-retry';
 import {
     EscrowCreateParams,
     EscrowResult,
@@ -22,6 +24,9 @@ export class StellarService {
     private readonly networkPassphrase: string;
     private readonly platformPublicKey: string;
     private readonly platformSecretKey: string;
+    private readonly retryMaxAttempts: number;
+    private readonly retryBaseDelayMs: number;
+    private readonly retryMaxDelayMs: number;
 
     constructor(private readonly configService: ConfigService) {
         const network = this.configService.get<string>('STELLAR_NETWORK', 'testnet');
@@ -38,6 +43,45 @@ export class StellarService {
 
         this.platformPublicKey = this.configService.getOrThrow<string>('STELLAR_PLATFORM_PUBLIC_KEY');
         this.platformSecretKey = this.configService.getOrThrow<string>('STELLAR_PLATFORM_SECRET_KEY');
+
+        this.retryMaxAttempts = Math.max(
+            1,
+            this.configService.get<number>('STELLAR_RETRY_MAX_ATTEMPTS', 3),
+        );
+        this.retryBaseDelayMs = Math.max(
+            0,
+            this.configService.get<number>('STELLAR_RETRY_BASE_DELAY_MS', 500),
+        );
+        this.retryMaxDelayMs = Math.max(
+            this.retryBaseDelayMs,
+            this.configService.get<number>('STELLAR_RETRY_MAX_DELAY_MS', 5000),
+        );
+    }
+
+    /**
+     * Submits a Stellar transaction with exponential-backoff retry on transient
+     * failures (5xx, 429, network errors). Deterministic rejections that
+     * carry Horizon `result_codes` are surfaced immediately — retrying those
+     * would only burn fees and sequence numbers.
+     */
+    private submitWithRetry(
+        transaction: StellarSdk.Transaction | StellarSdk.FeeBumpTransaction,
+        context: string,
+    ): Promise<StellarSdk.Horizon.HorizonApi.SubmitTransactionResponse> {
+        return retry(
+            () => this.server.submitTransaction(transaction),
+            {
+                maxAttempts: this.retryMaxAttempts,
+                baseDelayMs: this.retryBaseDelayMs,
+                maxDelayMs: this.retryMaxDelayMs,
+                isRetryable: isRetryableStellarError,
+                onRetry: (err, attempt, delayMs) => {
+                    this.logger.warn(
+                        `submitTransaction retry | context=${context} attempt=${attempt}/${this.retryMaxAttempts} delayMs=${delayMs} error=${(err as Error)?.message ?? 'unknown'}`,
+                    );
+                },
+            },
+        );
     }
 
     // ─────────────────────────────────────────────────────────────────────────────
@@ -264,7 +308,7 @@ export class StellarService {
         }
 
         try {
-            const response = await this.server.submitTransaction(transaction);
+            const response = await this.submitWithRetry(transaction, 'releaseUpfrontPayment');
             this.logger.log(`Upfront payment released | txHash=${response.hash}`);
             return {
                 transactionHash: response.hash,
@@ -355,7 +399,7 @@ export class StellarService {
         }
 
         try {
-        const response = await this.server.submitTransaction(transaction);
+        const response = await this.submitWithRetry(transaction, 'createEscrow');
         const balanceId = this.extractBalanceId(response);
 
         this.logger.log(`Escrow created | balanceId=${balanceId} txHash=${response.hash}`);
@@ -424,7 +468,7 @@ export class StellarService {
         }
 
         try {
-        const response = await this.server.submitTransaction(transaction);
+        const response = await this.submitWithRetry(transaction, 'releasePayment');
         this.logger.log(`Payment released | txHash=${response.hash}`);
 
         return {
@@ -487,7 +531,7 @@ export class StellarService {
         }
 
         try {
-        const response = await this.server.submitTransaction(transaction);
+        const response = await this.submitWithRetry(transaction, 'refund');
         this.logger.log(`Refund processed | txHash=${response.hash}`);
 
         return {
@@ -553,7 +597,7 @@ export class StellarService {
         transaction.sign(sourceKeypair);
 
         try {
-        const response = await this.server.submitTransaction(transaction);
+        const response = await this.submitWithRetry(transaction, 'setupMultiSig');
         this.logger.log(`Multisig configured | txHash=${response.hash}`);
 
         return {
@@ -726,7 +770,7 @@ export class StellarService {
         feeBumpTx.sign(feeSourceKeypair);
 
         try {
-            const response = await this.server.submitTransaction(feeBumpTx);
+            const response = await this.submitWithRetry(feeBumpTx, 'submitWithFeeBump');
             this.logger.log(`Fee-bump transaction submitted | outerHash=${response.hash} innerHash=${innerTx.hash().toString('hex')}`);
 
             return {

--- a/harvest-finance/backend/src/stellar/utils/stellar-retry.spec.ts
+++ b/harvest-finance/backend/src/stellar/utils/stellar-retry.spec.ts
@@ -1,0 +1,51 @@
+import { isRetryableStellarError } from './stellar-retry';
+
+describe('isRetryableStellarError', () => {
+  it('does not retry deterministic Stellar rejections (result_codes present)', () => {
+    const err = {
+      response: {
+        status: 400,
+        data: { extras: { result_codes: { transaction: 'tx_failed' } } },
+      },
+    };
+    expect(isRetryableStellarError(err)).toBe(false);
+  });
+
+  it('retries on HTTP 429 (rate limited)', () => {
+    expect(isRetryableStellarError({ response: { status: 429 } })).toBe(true);
+  });
+
+  it('retries on HTTP 5xx', () => {
+    expect(isRetryableStellarError({ response: { status: 502 } })).toBe(true);
+    expect(isRetryableStellarError({ response: { status: 504 } })).toBe(true);
+  });
+
+  it('does not retry on other 4xx', () => {
+    expect(isRetryableStellarError({ response: { status: 400 } })).toBe(false);
+    expect(isRetryableStellarError({ response: { status: 404 } })).toBe(false);
+    expect(isRetryableStellarError({ response: { status: 401 } })).toBe(false);
+  });
+
+  it('retries on transient network error codes', () => {
+    for (const code of [
+      'ECONNRESET',
+      'ECONNREFUSED',
+      'ETIMEDOUT',
+      'EAI_AGAIN',
+    ]) {
+      expect(isRetryableStellarError({ code })).toBe(true);
+    }
+  });
+
+  it('retries on errors whose message mentions a timeout', () => {
+    expect(
+      isRetryableStellarError({ message: 'Request timeout exceeded' }),
+    ).toBe(true);
+  });
+
+  it('does not retry on unknown / non-network errors', () => {
+    expect(isRetryableStellarError(new Error('something else'))).toBe(false);
+    expect(isRetryableStellarError(null)).toBe(false);
+    expect(isRetryableStellarError('string error')).toBe(false);
+  });
+});

--- a/harvest-finance/backend/src/stellar/utils/stellar-retry.ts
+++ b/harvest-finance/backend/src/stellar/utils/stellar-retry.ts
@@ -1,0 +1,49 @@
+/**
+ * Decides whether a failure from Horizon (or the underlying HTTP client)
+ * is worth retrying. We retry transient/network-level failures only —
+ * deterministic Stellar transaction rejections (carrying `result_codes`)
+ * will fail again on retry and only waste fee-bumps and ledger sequence.
+ */
+export function isRetryableStellarError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+
+  const e = err as {
+    response?: {
+      status?: number;
+      data?: { extras?: { result_codes?: unknown } };
+    };
+    code?: string;
+    isAxiosError?: boolean;
+    message?: string;
+  };
+
+  // Horizon told us the transaction was rejected on its merits — never retry.
+  if (e.response?.data?.extras?.result_codes) return false;
+
+  const status = e.response?.status;
+  if (typeof status === 'number') {
+    // 429 (rate limited) and 5xx (server / gateway failures) are worth a retry.
+    if (status === 429) return true;
+    if (status >= 500 && status < 600) return true;
+    // Other 4xx (400, 401, 404, etc.) are deterministic.
+    return false;
+  }
+
+  // No HTTP response → likely a network-layer failure.
+  const transientCodes = new Set([
+    'ECONNRESET',
+    'ECONNREFUSED',
+    'ECONNABORTED',
+    'ETIMEDOUT',
+    'EAI_AGAIN',
+    'ENETUNREACH',
+    'EHOSTUNREACH',
+    'EPIPE',
+  ]);
+  if (e.code && transientCodes.has(e.code)) return true;
+
+  // Some clients surface timeouts only via the message.
+  if (typeof e.message === 'string' && /timeout/i.test(e.message)) return true;
+
+  return false;
+}


### PR DESCRIPTION
## Summary
Wrap Horizon `submitTransaction` calls in `StellarService` with exponential-backoff retry, so transient network blips, 5xx, and 429s no longer surface as user-visible failures.

Closes #169.

## What changed
- New generic helper **`src/common/utils/retry.ts`** — `maxAttempts`, `baseDelayMs`, `maxDelayMs`, `factor`, `jitter`, `isRetryable` predicate, `onRetry` hook, and an injectable `sleep` for tests.
- New Stellar-specific predicate **`src/stellar/utils/stellar-retry.ts`** — retries transient failures only:
  - HTTP 5xx
  - HTTP 429 (rate limited)
  - Network-layer codes: `ECONNRESET`, `ECONNREFUSED`, `ECONNABORTED`, `ETIMEDOUT`, `EAI_AGAIN`, `ENETUNREACH`, `EHOSTUNREACH`, `EPIPE`
  - Errors whose message matches `/timeout/i`
  - Crucially, **NOT** retried: any error carrying Horizon `result_codes` (deterministic Stellar rejection — retrying would only burn fees and sequence numbers), nor other 4xx.
- **`StellarService`** gains a private `submitWithRetry(transaction, context)` helper. The six existing `submitTransaction` call sites — `createEscrow`, `releasePayment`, `releaseUpfrontPayment`, `refund`, `setupMultiSig`, `submitWithFeeBump` — now go through it. Each retry attempt is logged with attempt number, delay, error message, and operation context.
- Env-driven config (defaults are conservative):
  - `STELLAR_RETRY_MAX_ATTEMPTS=3`
  - `STELLAR_RETRY_BASE_DELAY_MS=500`
  - `STELLAR_RETRY_MAX_DELAY_MS=5000`

## Why a custom predicate (and why no retry on `result_codes`)
Stellar's failure modes are bimodal:
1. **Transient** — Horizon temporarily unreachable, gateway returns 502, rate limit hit. Retry is safe and helps.
2. **Deterministic** — `tx_bad_seq`, `tx_failed`, `op_underfunded`, etc. The transaction will fail identically on retry, but the fee is still deducted on each attempt and the sequence number is consumed. Retrying these is actively harmful.

The predicate's most important rule is the first one: if `result_codes` is present, **don't retry** — surface the error immediately so the caller can fix the input or refresh the sequence.

## Out of scope (good follow-ups)
- Retry the Soroban indexer's `rpcCall` (`getEvents` / `getLatestLedger`) — same helper applies, but the indexer's polling loop already retries on its next tick.
- Per-call-site override of attempts/delays (e.g. fee-bump might want fewer attempts).

## Test plan
- [x] `npm test` — 92/92 passing (13 new across the two new specs).
- [x] `npx tsc --noEmit -p tsconfig.json` — clean.
- [x] `npx nest build` — clean.
- [ ] Manual: kill the network mid-`createEscrow`, confirm retry log lines and eventual success.
- [ ] Manual: send a malformed transaction, confirm 400 surfaces immediately (no retries).