### PR TITLE
feat(backend): multi-chain yield bridge scaffold (closes #174)

### DIFF
--- a/harvest-finance/backend/src/app.module.ts
+++ b/harvest-finance/backend/src/app.module.ts
@@ -22,6 +22,7 @@ import { DatabaseModule } from './database/database.module';
 import { HealthModule } from './health/health.module';
 import { LoggerMiddleware } from './logger/logger.middleware';
 import { LoggerModule } from './logger/logger.module';
+import { MultiChainModule } from './multi-chain/multi-chain.module';
 import { OrdersModule } from './orders/orders.module';
 import { PortfolioModule } from './portfolio/portfolio.module';
 import { RealtimeModule } from './realtime/realtime.module';
@@ -128,6 +129,7 @@ import { CreateSorobanEvents1700000000011 } from './database/migrations/17000000
     StellarModule,
     SorobanModule,
     PortfolioModule,
+    MultiChainModule,
   ],
   controllers: [AppController],
   providers: [

--- a/harvest-finance/backend/src/main.ts
+++ b/harvest-finance/backend/src/main.ts
@@ -78,6 +78,7 @@ async function bootstrap() {
     .addTag('verifications', 'Delivery verification endpoints')
     .addTag('deliveries', 'Delivery management endpoints')
     .addTag('orders', 'Order management endpoints')
+    .addTag('Multi-chain', 'Cross-chain yield aggregation across registered chain adapters')
     .addTag('health', 'Health check endpoints')
     .build();
   const document = SwaggerModule.createDocument(app, config);

--- a/harvest-finance/backend/src/multi-chain/README.md
+++ b/harvest-finance/backend/src/multi-chain/README.md
@@ -1,0 +1,25 @@
+# Multi-chain data bridge
+
+A thin abstraction so Harvest's yield reporting can grow beyond Stellar without
+a refactor. Today only `StellarYieldAdapter` is wired.
+
+## Adding a new chain
+
+1. Implement `ChainAdapter` (see `interfaces/chain-adapter.interface.ts`).
+   - `chain` — lower-case key, e.g. `'ethereum'`, `'solana'`.
+   - `getYieldsForUser(userId)` — return `ChainYield[]` for the user. Return
+     `[]` (do not throw) when the user has no presence on this chain.
+2. Drop the new adapter into `MultiChainModule.providers`.
+3. Add it to the `CHAIN_ADAPTERS` factory's `inject` list and returned array:
+
+   ```ts
+   {
+     provide: CHAIN_ADAPTERS,
+     useFactory: (stellar, ethereum) => [stellar, ethereum],
+     inject: [StellarYieldAdapter, EthereumYieldAdapter],
+   }
+   ```
+
+That's it — `MultiChainService.getCrossChainYields` will fan out across the
+new adapter automatically. A single failing adapter is reported under
+`errors` rather than failing the whole response.

--- a/harvest-finance/backend/src/multi-chain/adapters/stellar-yield.adapter.spec.ts
+++ b/harvest-finance/backend/src/multi-chain/adapters/stellar-yield.adapter.spec.ts
@@ -1,0 +1,96 @@
+import { Repository } from 'typeorm';
+import { StellarYieldAdapter } from './stellar-yield.adapter';
+import { Deposit } from '../../database/entities/deposit.entity';
+import { Vault, VaultType } from '../../database/entities/vault.entity';
+
+describe('StellarYieldAdapter', () => {
+  const buildDeposits = (
+    rows: Array<{ vaultId: string; principal: string }>,
+  ): Repository<Deposit> =>
+    ({
+      createQueryBuilder: () => ({
+        select: () => ({
+          addSelect: () => ({
+            where: () => ({
+              andWhere: () => ({
+                groupBy: () => ({
+                  getRawMany: () => Promise.resolve(rows),
+                }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    }) as unknown as Repository<Deposit>;
+
+  const buildVaults = (
+    vaults: Array<{
+      id: string;
+      vaultName: string;
+      type: VaultType;
+      interestRate: number;
+    }>,
+  ): Repository<Vault> =>
+    ({
+      find: () => Promise.resolve(vaults),
+    }) as unknown as Repository<Vault>;
+
+  it('returns one ChainYield per confirmed-deposit vault', async () => {
+    const adapter = new StellarYieldAdapter(
+      buildDeposits([
+        { vaultId: 'v1', principal: '1500' },
+        { vaultId: 'v2', principal: '500' },
+      ]),
+      buildVaults([
+        {
+          id: 'v1',
+          vaultName: 'Maize Vault',
+          type: VaultType.CROP_PRODUCTION,
+          interestRate: 7.5,
+        },
+        {
+          id: 'v2',
+          vaultName: 'Equipment Fund',
+          type: VaultType.EQUIPMENT_FINANCING,
+          interestRate: 10,
+        },
+      ]),
+    );
+
+    const result = await adapter.getYieldsForUser('user-1');
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      chain: 'stellar',
+      positionId: 'v1',
+      positionName: 'Maize Vault',
+      principal: '1500.0000000',
+      asset: { code: 'XLM', issuer: null },
+      apr: 7.5,
+      estimatedAnnualYield: '112.5000000',
+    });
+    expect(result[1]).toMatchObject({
+      positionId: 'v2',
+      principal: '500.0000000',
+      apr: 10,
+      estimatedAnnualYield: '50.0000000',
+    });
+  });
+
+  it('returns [] when the user has no confirmed deposits', async () => {
+    const adapter = new StellarYieldAdapter(buildDeposits([]), buildVaults([]));
+    expect(await adapter.getYieldsForUser('lonely-user')).toEqual([]);
+  });
+
+  it('falls back gracefully when a vault row is missing', async () => {
+    const adapter = new StellarYieldAdapter(
+      buildDeposits([{ vaultId: 'orphan', principal: '42' }]),
+      buildVaults([]),
+    );
+
+    const result = await adapter.getYieldsForUser('user-2');
+    expect(result[0].positionName).toBe('Unknown Vault');
+    expect(result[0].apr).toBeNull();
+    expect(result[0].estimatedAnnualYield).toBeNull();
+  });
+});

--- a/harvest-finance/backend/src/multi-chain/adapters/stellar-yield.adapter.ts
+++ b/harvest-finance/backend/src/multi-chain/adapters/stellar-yield.adapter.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { Deposit, DepositStatus } from '../../database/entities/deposit.entity';
+import { Vault } from '../../database/entities/vault.entity';
+import {
+  ChainAdapter,
+  ChainYield,
+} from '../interfaces/chain-adapter.interface';
+
+/**
+ * Stellar implementation of `ChainAdapter`. Reads confirmed vault deposits
+ * from the application database — the ground-truth of what the user has
+ * locked in Harvest's Stellar vaults — and reports each vault as a position.
+ *
+ * No on-chain calls are made here: aggregating principals across many
+ * vaults via Horizon would be slow and redundant given we already index
+ * deposits in Postgres.
+ */
+@Injectable()
+export class StellarYieldAdapter implements ChainAdapter {
+  readonly chain = 'stellar';
+
+  constructor(
+    @InjectRepository(Deposit)
+    private readonly deposits: Repository<Deposit>,
+    @InjectRepository(Vault)
+    private readonly vaults: Repository<Vault>,
+  ) {}
+
+  async getYieldsForUser(userId: string): Promise<ChainYield[]> {
+    const rows = await this.deposits
+      .createQueryBuilder('deposit')
+      .select('deposit.vaultId', 'vaultId')
+      .addSelect('SUM(deposit.amount)', 'principal')
+      .where('deposit.userId = :userId', { userId })
+      .andWhere('deposit.status = :status', { status: DepositStatus.CONFIRMED })
+      .groupBy('deposit.vaultId')
+      .getRawMany<{ vaultId: string; principal: string }>();
+
+    if (rows.length === 0) return [];
+
+    const vaultIds = rows.map((r) => r.vaultId);
+    const vaults = await this.vaults.find({ where: { id: In(vaultIds) } });
+    const vaultMap = new Map(vaults.map((v) => [v.id, v]));
+
+    return rows.map((row): ChainYield => {
+      const vault = vaultMap.get(row.vaultId);
+      const principal = Number(row.principal) || 0;
+      const apr =
+        vault?.interestRate != null ? Number(vault.interestRate) : null;
+      return {
+        chain: this.chain,
+        positionId: row.vaultId,
+        positionName: vault?.vaultName ?? 'Unknown Vault',
+        principal: principal.toFixed(7),
+        asset: { code: 'XLM', issuer: null },
+        apr,
+        estimatedAnnualYield:
+          apr != null ? ((principal * apr) / 100).toFixed(7) : null,
+        metadata: {
+          vaultType: vault?.type,
+        },
+      };
+    });
+  }
+}

--- a/harvest-finance/backend/src/multi-chain/dto/multi-chain.dto.ts
+++ b/harvest-finance/backend/src/multi-chain/dto/multi-chain.dto.ts
@@ -1,0 +1,69 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ChainYieldAssetDto {
+  @ApiProperty({ example: 'XLM' })
+  code: string;
+
+  @ApiProperty({
+    example: null,
+    nullable: true,
+    description:
+      'Asset issuer (Stellar) or contract address (EVM). Null for native.',
+  })
+  issuer: string | null;
+}
+
+export class ChainYieldDto {
+  @ApiProperty({ example: 'stellar' })
+  chain: string;
+
+  @ApiProperty({ example: '123e4567-e89b-12d3-a456-426614174000' })
+  positionId: string;
+
+  @ApiProperty({ example: 'Maize Production Vault' })
+  positionName: string;
+
+  @ApiProperty({ example: '1500.0000000' })
+  principal: string;
+
+  @ApiProperty({ type: ChainYieldAssetDto })
+  asset: ChainYieldAssetDto;
+
+  @ApiProperty({ example: 7.5, nullable: true })
+  apr: number | null;
+
+  @ApiProperty({ example: '112.5000000', nullable: true })
+  estimatedAnnualYield: string | null;
+
+  @ApiProperty({ required: false, type: Object })
+  metadata?: Record<string, unknown>;
+}
+
+export class ChainErrorDto {
+  @ApiProperty({ example: 'ethereum' })
+  chain: string;
+
+  @ApiProperty({ example: 'RPC timeout' })
+  message: string;
+}
+
+export class MultiChainYieldsDto {
+  @ApiProperty({ example: 'a3f1c1c5-...-...-...-...' })
+  userId: string;
+
+  @ApiProperty({ example: '2026-04-26T18:42:11.012Z' })
+  generatedAt: string;
+
+  @ApiProperty({ type: [ChainYieldDto] })
+  positions: ChainYieldDto[];
+
+  @ApiProperty({ example: ['stellar'] })
+  chainsQueried: string[];
+
+  @ApiProperty({
+    type: [ChainErrorDto],
+    description:
+      'Chains whose adapter threw — the rest of the response is still valid.',
+  })
+  errors: ChainErrorDto[];
+}

--- a/harvest-finance/backend/src/multi-chain/interfaces/chain-adapter.interface.ts
+++ b/harvest-finance/backend/src/multi-chain/interfaces/chain-adapter.interface.ts
@@ -1,0 +1,55 @@
+/**
+ * A yield-bearing position on a specific chain.
+ *
+ * Adapters return a flat array of these so the service layer can aggregate
+ * across chains without knowing anything about the underlying network.
+ */
+export interface ChainYield {
+  /** Lower-case chain key — e.g. `stellar`, `ethereum`, `solana`. */
+  chain: string;
+
+  /**
+   * Stable identifier for the position itself (e.g. a Stellar vault id, an
+   * EVM contract+account tuple). Combined with `chain` it MUST be unique.
+   */
+  positionId: string;
+
+  /** Human-friendly label for UIs. */
+  positionName: string;
+
+  /** Principal amount as a decimal string, in the asset's native units. */
+  principal: string;
+
+  /** Asset metadata. `issuer` is chain-specific (Stellar issuer, EVM contract). */
+  asset: {
+    code: string;
+    issuer: string | null;
+  };
+
+  /** Annual percentage rate in percent (e.g. 7.5). Null if unknown. */
+  apr: number | null;
+
+  /** principal * apr/100 (decimal string). Null when apr is unknown. */
+  estimatedAnnualYield: string | null;
+
+  /** Adapter-specific extras the controller passes through verbatim. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Implemented once per supported chain. Bring up a new chain by writing one
+ * of these and registering it in the `CHAIN_ADAPTERS` provider array.
+ */
+export interface ChainAdapter {
+  /** Lower-case identifier — must match `ChainYield.chain`. */
+  readonly chain: string;
+
+  /**
+   * Fetch yield-bearing positions held by a user on this chain. Should
+   * return `[]` (not throw) when the user has no presence on this chain.
+   */
+  getYieldsForUser(userId: string): Promise<ChainYield[]>;
+}
+
+/** DI token used to register the array of `ChainAdapter`s with Nest. */
+export const CHAIN_ADAPTERS = Symbol('CHAIN_ADAPTERS');

--- a/harvest-finance/backend/src/multi-chain/multi-chain.controller.ts
+++ b/harvest-finance/backend/src/multi-chain/multi-chain.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { MultiChainYieldsDto } from './dto/multi-chain.dto';
+import { MultiChainService } from './multi-chain.service';
+
+@ApiTags('Multi-chain')
+@ApiBearerAuth('JWT-auth')
+@Controller('api/v1/multi-chain')
+@UseGuards(JwtAuthGuard)
+export class MultiChainController {
+  constructor(private readonly service: MultiChainService) {}
+
+  @Get('yields')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary:
+      'Aggregate yield-bearing positions for the authenticated user across all registered chains',
+    description:
+      'Currently Stellar is the only registered chain. The response shape is designed so additional chains slot in without breaking clients — any failing chain is reported under `errors` while the rest of the data is returned.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Cross-chain yields aggregated',
+    type: MultiChainYieldsDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized — invalid or missing token',
+  })
+  async getYields(
+    @Request() req: { user: { id: string } },
+  ): Promise<MultiChainYieldsDto> {
+    return this.service.getCrossChainYields(req.user.id);
+  }
+}

--- a/harvest-finance/backend/src/multi-chain/multi-chain.module.ts
+++ b/harvest-finance/backend/src/multi-chain/multi-chain.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
+import { Deposit } from '../database/entities/deposit.entity';
+import { Vault } from '../database/entities/vault.entity';
+import { StellarYieldAdapter } from './adapters/stellar-yield.adapter';
+import { CHAIN_ADAPTERS } from './interfaces/chain-adapter.interface';
+import { MultiChainController } from './multi-chain.controller';
+import { MultiChainService } from './multi-chain.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Deposit, Vault]), AuthModule],
+  controllers: [MultiChainController],
+  providers: [
+    StellarYieldAdapter,
+    {
+      provide: CHAIN_ADAPTERS,
+      useFactory: (stellar: StellarYieldAdapter) => [stellar],
+      inject: [StellarYieldAdapter],
+    },
+    MultiChainService,
+  ],
+  exports: [MultiChainService],
+})
+export class MultiChainModule {}

--- a/harvest-finance/backend/src/multi-chain/multi-chain.service.spec.ts
+++ b/harvest-finance/backend/src/multi-chain/multi-chain.service.spec.ts
@@ -1,0 +1,74 @@
+import { MultiChainService } from './multi-chain.service';
+import { ChainAdapter, ChainYield } from './interfaces/chain-adapter.interface';
+
+const makeYield = (chain: string, id: string): ChainYield => ({
+  chain,
+  positionId: id,
+  positionName: `${chain} pos ${id}`,
+  principal: '100.0000000',
+  asset: { code: 'XLM', issuer: null },
+  apr: 5,
+  estimatedAnnualYield: '5.0000000',
+});
+
+describe('MultiChainService', () => {
+  it('aggregates positions from every adapter in parallel', async () => {
+    const adapters: ChainAdapter[] = [
+      {
+        chain: 'stellar',
+        getYieldsForUser: jest
+          .fn()
+          .mockResolvedValue([makeYield('stellar', 'v1')]),
+      },
+      {
+        chain: 'ethereum',
+        getYieldsForUser: jest
+          .fn()
+          .mockResolvedValue([makeYield('ethereum', '0xabc')]),
+      },
+    ];
+    const service = new MultiChainService(adapters);
+
+    const result = await service.getCrossChainYields('user-1');
+
+    expect(result.userId).toBe('user-1');
+    expect(result.chainsQueried).toEqual(['stellar', 'ethereum']);
+    expect(result.positions).toHaveLength(2);
+    expect(result.positions.map((p) => p.chain).sort()).toEqual([
+      'ethereum',
+      'stellar',
+    ]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('records failures under errors and still returns successful adapters', async () => {
+    const adapters: ChainAdapter[] = [
+      {
+        chain: 'stellar',
+        getYieldsForUser: jest
+          .fn()
+          .mockResolvedValue([makeYield('stellar', 'v1')]),
+      },
+      {
+        chain: 'ethereum',
+        getYieldsForUser: jest.fn().mockRejectedValue(new Error('RPC down')),
+      },
+    ];
+    const service = new MultiChainService(adapters);
+
+    const result = await service.getCrossChainYields('user-2');
+
+    expect(result.positions).toHaveLength(1);
+    expect(result.positions[0].chain).toBe('stellar');
+    expect(result.errors).toEqual([{ chain: 'ethereum', message: 'RPC down' }]);
+  });
+
+  it('returns an empty position list when no adapters are registered', async () => {
+    const service = new MultiChainService([]);
+    const result = await service.getCrossChainYields('user-3');
+
+    expect(result.positions).toEqual([]);
+    expect(result.chainsQueried).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+});

--- a/harvest-finance/backend/src/multi-chain/multi-chain.service.ts
+++ b/harvest-finance/backend/src/multi-chain/multi-chain.service.ts
@@ -1,0 +1,54 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import {
+  CHAIN_ADAPTERS,
+  ChainAdapter,
+} from './interfaces/chain-adapter.interface';
+import { MultiChainYieldsDto } from './dto/multi-chain.dto';
+import { ChainYield } from './interfaces/chain-adapter.interface';
+
+@Injectable()
+export class MultiChainService {
+  private readonly logger = new Logger(MultiChainService.name);
+
+  constructor(
+    @Inject(CHAIN_ADAPTERS) private readonly adapters: ChainAdapter[],
+  ) {}
+
+  /**
+   * Fan out across every registered chain adapter in parallel and aggregate
+   * the results. A single adapter failure is recorded under `errors` rather
+   * than failing the whole response — partial data is more useful than none.
+   */
+  async getCrossChainYields(userId: string): Promise<MultiChainYieldsDto> {
+    const settled = await Promise.allSettled(
+      this.adapters.map((adapter) => adapter.getYieldsForUser(userId)),
+    );
+
+    const positions: ChainYield[] = [];
+    const errors: { chain: string; message: string }[] = [];
+
+    settled.forEach((result, idx) => {
+      const adapter = this.adapters[idx];
+      if (result.status === 'fulfilled') {
+        positions.push(...result.value);
+      } else {
+        const message =
+          result.reason instanceof Error
+            ? result.reason.message
+            : 'unknown error';
+        this.logger.warn(
+          `Adapter '${adapter.chain}' failed for user=${userId}: ${message}`,
+        );
+        errors.push({ chain: adapter.chain, message });
+      }
+    });
+
+    return {
+      userId,
+      generatedAt: new Date().toISOString(),
+      positions,
+      chainsQueried: this.adapters.map((a) => a.chain),
+      errors,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
A thin abstraction so Harvest's yield reporting can grow beyond Stellar without a refactor. Today only the Stellar adapter is wired — additional chains slot in by implementing a single interface and registering the provider.

Closes #174.

> The issue body explicitly marks this as **Optional**: *"Logic to track cross-chain yields if the protocol expands beyond Stellar."* This PR ships the scaffold only — no real EVM/Solana/etc. integration. Stubbing chains we don't actually support would just rot and mislead readers.

## What's added
| Path | Role |
| --- | --- |
| `interfaces/chain-adapter.interface.ts` | `ChainAdapter` contract + `ChainYield` shape + `CHAIN_ADAPTERS` DI token |
| `dto/multi-chain.dto.ts` | Swagger-annotated response DTOs |
| `adapters/stellar-yield.adapter.ts` | Real Stellar implementation reading confirmed deposits from Postgres |
| `multi-chain.service.ts` | Adapter registry + parallel `Promise.allSettled` fan-out |
| `multi-chain.controller.ts` | `GET /api/v1/multi-chain/yields` (Bearer-auth) |
| `multi-chain.module.ts` | Wires the registry; one line to extend |
| `README.md` | One-paragraph guide on adding a new chain |

## Endpoint
```
GET /api/v1/multi-chain/yields
Authorization: Bearer <token>
```

Response shape:
```json
{
  "userId": "…",
  "generatedAt": "2026-04-26T18:42:11.012Z",
  "positions": [
    {
      "chain": "stellar",
      "positionId": "<vault-uuid>",
      "positionName": "Maize Vault",
      "principal": "1500.0000000",
      "asset": { "code": "XLM", "issuer": null },
      "apr": 7.5,
      "estimatedAnnualYield": "112.5000000",
      "metadata": { "vaultType": "CROP_PRODUCTION" }
    }
  ],
  "chainsQueried": ["stellar"],
  "errors": []
}
```

## Failure handling
The service uses `Promise.allSettled`. If a single adapter throws (e.g. RPC down), the response still returns successful chains' data, with the failed chain logged under `errors[]`. Partial cross-chain data is more useful than none.

## Adding a new chain
Implement `ChainAdapter`, register the provider, add it to the `CHAIN_ADAPTERS` factory's `inject` list. That's all — see `src/multi-chain/README.md`.

## Test plan
- [x] `npm test` — 85/85, including 6 new tests across the service registry and the Stellar adapter.
- [x] `npx tsc --noEmit -p tsconfig.json` — clean.
- [x] `npx nest build` — clean.
- [ ] Manual: hit `GET /api/v1/multi-chain/yields` with a valid JWT for a user that has confirmed deposits, confirm vault positions render with APR + estimated annual yield.
- [ ] Manual: temporarily make `StellarYieldAdapter.getYieldsForUser` throw, confirm the response surfaces it under `errors[]` instead of 5xxing.

## Out of scope (good follow-ups)
- Real adapters for EVM / Solana / etc. (will need their own PRs with proper RPC clients, indexing, and key-format validation).
- Persisting cross-chain account links to a user (today the response only covers chains where the user is identified by their Harvest userId; a future EVM adapter would need a `user_chain_accounts` table).
- Caching the response in Redis — `MultiChainService.getCrossChainYields` is read-only and the data is bounded.