### PR TITLE
feat(backend): implement global soroban exception filter (#164)

### DIFF
--- a/harvest-finance/backend/src/common/filters/soroban-exception.filter.ts
+++ b/harvest-finance/backend/src/common/filters/soroban-exception.filter.ts
@@ -1,0 +1,68 @@
+import { 
+  ExceptionFilter, 
+  Catch, 
+  ArgumentsHost, 
+  HttpException, 
+  HttpStatus, 
+  Logger 
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+@Catch()
+export class SorobanExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(SorobanExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    // Defer to standard NestJS handling for existing HttpExceptions
+    if (exception instanceof HttpException) {
+      const status = exception.getStatus();
+      return response.status(status).json(exception.getResponse());
+    }
+
+    const errMessage = exception instanceof Error ? exception.message : String(exception);
+    
+    // Identify Soroban/Rust specific error signatures
+    const isSorobanError = errMessage.includes('HostError') || 
+                           errMessage.includes('Soroban') || 
+                           errMessage.includes('stellar') || 
+                           errMessage.includes('tx_failed');
+
+    if (isSorobanError) {
+      this.logger.error(`Soroban Exception Caught: ${errMessage}`, exception instanceof Error ? exception.stack : '');
+
+      // Translate cryptic Rust/Soroban errors into friendly UI messages
+      let cleanMessage = 'A blockchain transaction error occurred.';
+      if (errMessage.toLowerCase().includes('timeout')) {
+        cleanMessage = 'The transaction timed out. Please try again.';
+      } else if (errMessage.includes('InvalidInput')) {
+        cleanMessage = 'Invalid input provided to the smart contract.';
+      } else if (errMessage.includes('Auth') || errMessage.includes('auth_failed')) {
+        cleanMessage = 'Transaction authorization failed. Please check your signature.';
+      }
+
+      return response.status(HttpStatus.BAD_REQUEST).json({
+        success: false,
+        statusCode: HttpStatus.BAD_REQUEST,
+        error: 'SorobanContractError',
+        message: cleanMessage,
+        details: process.env.NODE_ENV === 'development' ? errMessage : undefined,
+        timestamp: new Date().toISOString(),
+        path: request.url,
+      });
+    }
+
+    // Fallback for generic, non-Soroban unhandled server errors
+    this.logger.error(`Unhandled Exception: ${errMessage}`, exception instanceof Error ? exception.stack : '');
+    return response.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      message: 'An unexpected internal server error occurred',
+      timestamp: new Date().toISOString(),
+      path: request.url,
+    });
+  }
+}

--- a/harvest-finance/backend/src/main.ts
+++ b/harvest-finance/backend/src/main.ts
@@ -6,6 +6,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 import { ThrottlerExceptionFilter } from './common/filters/throttler-exception.filter';
+import { SorobanExceptionFilter } from './common/filters/soroban-exception.filter';
 import { CustomLoggerService } from './logger/custom-logger.service';
 
 async function bootstrap() {
@@ -14,10 +15,14 @@ async function bootstrap() {
   });
   const customLogger = app.get(CustomLoggerService);
   app.useLogger(customLogger);
+  
+  // Register the global filters, including the new Soroban filter
   app.useGlobalFilters(
     new HttpExceptionFilter(customLogger),
     new ThrottlerExceptionFilter(),
+    new SorobanExceptionFilter(),
   );
+  
   app.useGlobalPipes(
     new ValidationPipe({
       transform: true,


### PR DESCRIPTION
Closes #164

### **Description**
This PR introduces a global exception filter to intercept and translate cryptic Soroban/Rust smart contract errors into standardized, user-friendly JSON responses for the frontend.

### **Changes**
* Created `SorobanExceptionFilter` in `src/common/filters/soroban-exception.filter.ts`.
* Configured the filter to catch `HostError`, timeout, and authorization failures, parsing them into standard 400 Bad Request payloads with clear messaging.
* Registered the filter globally in `src/main.ts` alongside the existing HTTP and Throttler filters.

---
**⚠️ Note to Maintainers:** I was unable to run a clean build or test pass locally because the `main` branch currently has 56 TypeScript compiler errors. These include duplicate module imports in `app.module.ts` and un-commented raw text on line 77 of `soroban-storage.service.ts`. My changes are isolated to the filter and `main.ts`.