### PR TITLE
test(contracts): add multi-user concurrency tests for vault (#150)

### DIFF
--- a/contracts/test/VaultConcurrency.t.sol
+++ b/contracts/test/VaultConcurrency.t.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "../src/Vault.sol";
+import "../src/MockERC20.sol";
+
+contract VaultConcurrencyTest is Test {
+    Vault public vault;
+    MockERC20 public token;
+
+    address[] public users;
+
+    function setUp() public {
+        // Deploy mock token and vault
+        token = new MockERC20();
+        vault = new Vault(address(token));
+
+        // Set up 5 concurrent users
+        for(uint256 i = 1; i <= 5; i++) {
+            address user = address(uint160(i));
+            users.push(user);
+            
+            // Mint tokens to user and approve the vault
+            token.mint(user, 10000 ether);
+            vm.prank(user);
+            token.approve(address(vault), type(uint256).max);
+        }
+    }
+
+    function test_ConcurrentDeposits() public {
+        uint256 depositAmount = 100 ether;
+
+        // Simulate multiple users depositing in the exact same block/timestamp
+        for(uint256 i = 0; i < users.length; i++) {
+            vm.prank(users[i]);
+            vault.deposit(depositAmount, users[i]);
+        }
+
+        // Assert shared state consistency
+        assertEq(token.balanceOf(address(vault)), depositAmount * users.length, "Total vault balance mismatch");
+        assertEq(vault.totalSupply(), depositAmount * users.length, "Total shares mismatch");
+
+        // Verify individual states
+        for(uint256 i = 0; i < users.length; i++) {
+            assertEq(vault.balanceOf(users[i]), depositAmount, "Individual share mismatch");
+        }
+    }
+
+    function test_ConcurrentDepositsAndWithdrawals() public {
+        // First, simulate the concurrent deposits
+        test_ConcurrentDeposits();
+
+        // Advance to the next block to simulate a new transaction batch
+        vm.roll(block.number + 1);
+
+        uint256 withdrawAmount = 50 ether;
+
+        // Simulate a subset of users withdrawing simultaneously
+        for(uint256 i = 0; i < 3; i++) {
+            vm.prank(users[i]);
+            vault.withdraw(withdrawAmount, users[i], users[i]);
+        }
+
+        // Assert shared state consistency after mixed operations
+        uint256 expectedRemaining = (100 ether * 5) - (withdrawAmount * 3);
+        assertEq(token.balanceOf(address(vault)), expectedRemaining, "Vault balance mismatch after withdrawals");
+        assertEq(vault.totalSupply(), expectedRemaining, "Total shares mismatch after withdrawals");
+    }
+}


### PR DESCRIPTION
Closes #150

### **Description**
This PR introduces concurrency testing to verify that the Vault maintains strict accounting and shared state consistency when multiple users interact with it simultaneously.

### **Changes**
* Added `VaultConcurrency.t.sol` to the Foundry test suite.
* Implemented `test_ConcurrentDeposits` to simulate batch deposits within the same block, asserting global and individual share alignment.
* Implemented `test_ConcurrentDepositsAndWithdrawals` to verify state consistency during interleaved user actions.

---
**⚠️ Note to Maintainers:** 1. The issue description specifically referenced Soroban `DataKey` consistency, but since the `contracts/` directory is built with Solidity and Foundry, I implemented these concurrency tests for the EVM `Vault.sol` contract using `vm.prank` and block simulation. If there is a separate Rust repository where this was intended to live, please let me know!
2. I was unable to execute `forge test` locally because the `main` branch currently fails to compile. There is a path resolution issue with the `@openzeppelin/contracts-upgradeable` imports, and a syntax error in `test/VaultInvariant.t.sol` on line 89 (`Expected '(' but got identifier`).