### PR TITLE
feat(frontend): empty states, mobile layout, dark mode, and transaction status UI

### DIFF
--- a/harvest-finance/frontend/src/app/transactions/page.tsx
+++ b/harvest-finance/frontend/src/app/transactions/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { 
+import {
   Card,
   CardHeader,
   CardBody,
@@ -17,6 +17,7 @@ import {
   Inline,
   ThemeToggle,
   TransactionRowSkeleton,
+  TransactionStatusBadge,
 } from '@/components/ui';
 import { Download, ArrowRightLeft, Calendar, Tag, Coins, Info } from 'lucide-react';
 import { useAuthStore } from '@/lib/stores/auth-store';
@@ -141,10 +142,7 @@ export default function TransactionsPage() {
                   <TableCell className="text-gray-700 dark:text-gray-200">{tx.vault}</TableCell>
                   <TableCell className="font-bold text-gray-900 dark:text-white">{tx.amount}</TableCell>
                   <TableCell>
-                    <div className="flex items-center gap-1.5 text-sm text-harvest-green-600 dark:text-harvest-green-400 font-medium">
-                      <div className="w-1.5 h-1.5 rounded-full bg-harvest-green-500" />
-                      {tx.status}
-                    </div>
+                    <TransactionStatusBadge status={tx.status} />
                   </TableCell>
                   <TableCell className="text-right">
                     <Button variant="ghost" size="sm">Details</Button>

--- a/harvest-finance/frontend/src/app/transactions/page.tsx
+++ b/harvest-finance/frontend/src/app/transactions/page.tsx
@@ -109,7 +109,8 @@ export default function TransactionsPage() {
       </div>
 
       <Card variant="default">
-        <CardBody className="p-0">
+        <CardBody className="p-0 overflow-x-auto">
+          <div className="min-w-[600px]">
           <Table>
             <TableHeader>
               <TableRow>
@@ -152,6 +153,7 @@ export default function TransactionsPage() {
               ))}
             </TableBody>
           </Table>
+          </div>
         </CardBody>
       </Card>
       

--- a/harvest-finance/frontend/src/components/layout/DashboardShell.tsx
+++ b/harvest-finance/frontend/src/components/layout/DashboardShell.tsx
@@ -40,7 +40,7 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
       </a>
       <Sidebar />
 
-      <div className="flex-1 flex min-w-0 flex-col overflow-hidden h-screen">
+      <div className="flex-1 flex min-w-0 flex-col overflow-x-hidden min-h-screen md:h-screen md:overflow-hidden">
        <header className="md:hidden sticky top-0 z-20 flex h-16 items-center justify-between border-b border-gray-200 dark:border-[rgba(141,187,85,0.15)] bg-white dark:bg-[#162a1a] px-4 shadow-sm">
   <Link href="/" className="text-lg font-bold text-harvest-green-600 dark:text-harvest-green-400" aria-label="Harvest Finance home">
             Harvest
@@ -141,7 +141,7 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
         )}
 
         <main className="flex-1 overflow-y-auto focus:outline-none" role="main" id="main-content" tabIndex={-1}>
-          <div className="mx-auto max-w-7xl p-4 md:p-6 lg:p-8">{children}</div>
+          <div className="mx-auto max-w-7xl w-full px-3 py-4 sm:px-4 md:px-6 md:py-6 lg:px-8 lg:py-8">{children}</div>
         </main>
       </div>
     </div>

--- a/harvest-finance/frontend/src/components/providers/ThemeProvider.tsx
+++ b/harvest-finance/frontend/src/components/providers/ThemeProvider.tsx
@@ -1,21 +1,16 @@
 'use client';
 
-import { useState, useEffect } from 'react';
 import { ThemeProvider as NextThemesProvider } from 'next-themes';
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  if (!mounted) {
-    return <>{children}</>;
-  }
-
   return (
-    <NextThemesProvider attribute="class" defaultTheme="system" enableSystem>
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      storageKey="harvest-finance-theme"
+      disableTransitionOnChange
+    >
       {children}
     </NextThemesProvider>
   );

--- a/harvest-finance/frontend/src/components/ui/EmptyState/EmptyState.tsx
+++ b/harvest-finance/frontend/src/components/ui/EmptyState/EmptyState.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import React from 'react';
+import { Inbox, BarChart2, Layers, LucideIcon } from 'lucide-react';
+import { Button } from '../Button';
+
+export type EmptyStateVariant = 'no-deposits' | 'no-data' | 'no-vaults' | 'custom';
+
+interface PresetConfig {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  ctaLabel?: string;
+  ctaHref?: string;
+}
+
+const PRESETS: Record<Exclude<EmptyStateVariant, 'custom'>, PresetConfig> = {
+  'no-deposits': {
+    icon: Inbox,
+    title: 'No deposits yet',
+    description: 'You have not made any deposits. Start earning yield by depositing into a vault.',
+    ctaLabel: 'Browse Vaults',
+    ctaHref: '/vaults',
+  },
+  'no-data': {
+    icon: BarChart2,
+    title: 'No data available',
+    description: 'There is no data to display at the moment. Check back later.',
+  },
+  'no-vaults': {
+    icon: Layers,
+    title: 'No vaults found',
+    description: 'No vaults match your current filters. Try adjusting your search criteria.',
+    ctaLabel: 'Clear Filters',
+  },
+};
+
+export interface EmptyStateProps {
+  variant?: EmptyStateVariant;
+  icon?: LucideIcon;
+  title?: string;
+  description?: string;
+  ctaLabel?: string;
+  ctaHref?: string;
+  onCtaClick?: () => void;
+  className?: string;
+}
+
+export function EmptyState({
+  variant = 'no-data',
+  icon,
+  title,
+  description,
+  ctaLabel,
+  ctaHref,
+  onCtaClick,
+  className = '',
+}: EmptyStateProps) {
+  const preset = variant !== 'custom' ? PRESETS[variant] : null;
+
+  const Icon = icon ?? preset?.icon ?? Inbox;
+  const resolvedTitle = title ?? preset?.title ?? 'Nothing here';
+  const resolvedDescription = description ?? preset?.description ?? '';
+  const resolvedCtaLabel = ctaLabel ?? preset?.ctaLabel;
+  const resolvedCtaHref = ctaHref ?? preset?.ctaHref;
+
+  const handleCta = () => {
+    if (onCtaClick) {
+      onCtaClick();
+    } else if (resolvedCtaHref) {
+      window.location.href = resolvedCtaHref;
+    }
+  };
+
+  return (
+    <div
+      className={`flex flex-col items-center justify-center py-16 px-6 text-center ${className}`}
+      role="status"
+      aria-label={resolvedTitle}
+    >
+      <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-harvest-green-50 dark:bg-harvest-green-900/20">
+        <Icon className="h-8 w-8 text-harvest-green-500 dark:text-harvest-green-400" aria-hidden="true" />
+      </div>
+      <h3 className="mb-2 text-lg font-semibold text-gray-900 dark:text-white">{resolvedTitle}</h3>
+      {resolvedDescription && (
+        <p className="mb-6 max-w-sm text-sm text-gray-500 dark:text-gray-400">{resolvedDescription}</p>
+      )}
+      {resolvedCtaLabel && (
+        <Button variant="primary" size="sm" onClick={handleCta}>
+          {resolvedCtaLabel}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/harvest-finance/frontend/src/components/ui/EmptyState/index.ts
+++ b/harvest-finance/frontend/src/components/ui/EmptyState/index.ts
@@ -1,0 +1,2 @@
+export { EmptyState } from './EmptyState';
+export type { EmptyStateProps, EmptyStateVariant } from './EmptyState';

--- a/harvest-finance/frontend/src/components/ui/TransactionStatus/TransactionStatus.tsx
+++ b/harvest-finance/frontend/src/components/ui/TransactionStatus/TransactionStatus.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import React from 'react';
+import { CheckCircle2, XCircle, Clock, Loader2, AlertCircle } from 'lucide-react';
+
+export type TxStatus = 'PENDING' | 'CONFIRMED' | 'FAILED' | 'CLAIMED' | 'PROCESSING' | string;
+
+interface StatusConfig {
+  icon: React.ReactNode;
+  label: string;
+  className: string;
+}
+
+function getStatusConfig(status: TxStatus): StatusConfig {
+  switch (status) {
+    case 'CONFIRMED':
+    case 'CLAIMED':
+      return {
+        icon: <CheckCircle2 className="w-3.5 h-3.5" aria-hidden="true" />,
+        label: status === 'CLAIMED' ? 'Claimed' : 'Confirmed',
+        className:
+          'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-900/20 dark:text-emerald-400 dark:border-emerald-800/50',
+      };
+    case 'FAILED':
+      return {
+        icon: <XCircle className="w-3.5 h-3.5" aria-hidden="true" />,
+        label: 'Failed',
+        className:
+          'bg-red-50 text-red-700 border-red-200 dark:bg-red-900/20 dark:text-red-400 dark:border-red-800/50',
+      };
+    case 'PROCESSING':
+      return {
+        icon: <Loader2 className="w-3.5 h-3.5 animate-spin" aria-hidden="true" />,
+        label: 'Processing',
+        className:
+          'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-900/20 dark:text-blue-400 dark:border-blue-800/50',
+      };
+    case 'PENDING':
+      return {
+        icon: <Clock className="w-3.5 h-3.5" aria-hidden="true" />,
+        label: 'Pending',
+        className:
+          'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-900/20 dark:text-amber-400 dark:border-amber-800/50',
+      };
+    default:
+      return {
+        icon: <AlertCircle className="w-3.5 h-3.5" aria-hidden="true" />,
+        label: status,
+        className:
+          'bg-gray-50 text-gray-600 border-gray-200 dark:bg-gray-800/40 dark:text-gray-400 dark:border-gray-700',
+      };
+  }
+}
+
+interface TransactionStatusBadgeProps {
+  status: TxStatus;
+  className?: string;
+}
+
+export function TransactionStatusBadge({ status, className = '' }: TransactionStatusBadgeProps) {
+  const config = getStatusConfig(status);
+  return (
+    <span
+      role="status"
+      aria-label={`Transaction status: ${config.label}`}
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium ${config.className} ${className}`}
+    >
+      {config.icon}
+      {config.label}
+    </span>
+  );
+}
+
+interface TransactionStatusDotProps {
+  status: TxStatus;
+  className?: string;
+}
+
+export function TransactionStatusDot({ status, className = '' }: TransactionStatusDotProps) {
+  const isPulsing = status === 'PENDING' || status === 'PROCESSING';
+
+  const dotColor =
+    status === 'CONFIRMED' || status === 'CLAIMED'
+      ? 'bg-emerald-500'
+      : status === 'FAILED'
+        ? 'bg-red-500'
+        : status === 'PROCESSING'
+          ? 'bg-blue-500'
+          : status === 'PENDING'
+            ? 'bg-amber-500'
+            : 'bg-gray-400';
+
+  return (
+    <span className={`relative inline-flex h-2.5 w-2.5 ${className}`} aria-hidden="true">
+      {isPulsing && (
+        <span
+          className={`absolute inline-flex h-full w-full animate-ping rounded-full ${dotColor} opacity-60`}
+        />
+      )}
+      <span className={`relative inline-flex h-2.5 w-2.5 rounded-full ${dotColor}`} />
+    </span>
+  );
+}

--- a/harvest-finance/frontend/src/components/ui/TransactionStatus/index.ts
+++ b/harvest-finance/frontend/src/components/ui/TransactionStatus/index.ts
@@ -1,0 +1,2 @@
+export { TransactionStatusBadge, TransactionStatusDot } from './TransactionStatus';
+export type { TxStatus } from './TransactionStatus';

--- a/harvest-finance/frontend/src/components/ui/index.ts
+++ b/harvest-finance/frontend/src/components/ui/index.ts
@@ -107,3 +107,10 @@ export { Skeleton, VaultCardSkeleton, VaultTableRowSkeleton, TransactionRowSkele
 
 export { Tooltip } from './Tooltip';
 export type { TooltipProps } from './Tooltip';
+
+// ============================================
+// Empty State
+// ============================================
+
+export { EmptyState } from './EmptyState';
+export type { EmptyStateProps, EmptyStateVariant } from './EmptyState';

--- a/harvest-finance/frontend/src/components/ui/index.ts
+++ b/harvest-finance/frontend/src/components/ui/index.ts
@@ -114,3 +114,10 @@ export type { TooltipProps } from './Tooltip';
 
 export { EmptyState } from './EmptyState';
 export type { EmptyStateProps, EmptyStateVariant } from './EmptyState';
+
+// ============================================
+// Transaction Status
+// ============================================
+
+export { TransactionStatusBadge, TransactionStatusDot } from './TransactionStatus';
+export type { TxStatus } from './TransactionStatus';


### PR DESCRIPTION
## Summary

- **#252** — Add reusable `EmptyState` component with `no-deposits`, `no-data`, `no-vaults` presets and a `custom` variant; exported from `@/components/ui`
- **#253** — Fix mobile overflow clipping in `DashboardShell` (`h-screen` → `min-h-screen` on mobile, `md:h-screen` on desktop); add `overflow-x-auto` + `min-w-[600px]` wrapper on transactions table to prevent column collapse
- **#254** — Remove `mounted` guard from `ThemeProvider` that was causing FOUC; delegate theme flicker prevention to `next-themes` built-in inline script; add `storageKey` and `disableTransitionOnChange`
- **#255** — Add `TransactionStatusBadge` (color-coded badge with icon per status) and `TransactionStatusDot` (animated ping dot for pending states); wire `TransactionStatusBadge` into the transactions page replacing the plain dot+text

Closes #252
Closes #253
Closes #254
Closes #255

## Test plan

- [ ] Navigate to `/dashboard` on a narrow viewport — content should scroll without being clipped
- [ ] Open `/transactions` on mobile — table should scroll horizontally, not overflow the viewport
- [ ] Toggle dark/light/system theme — no white flash on page load; theme persists across reloads
- [ ] Verify transactions table shows color-coded status badges: green for CONFIRMED/CLAIMED, amber for PENDING, blue for PROCESSING, red for FAILED
- [ ] Verify PENDING/PROCESSING status dots show animated ping
- [ ] Use `EmptyState` component in a page — confirm presets and custom variant render correctly