### PR TITLE
feat(ui): Error State UI Standardization – reusable ErrorState component

### DIFF
--- a/harvest-finance/frontend/src/app/components-demo/page.tsx
+++ b/harvest-finance/frontend/src/app/components-demo/page.tsx
@@ -19,6 +19,7 @@ import {
   Section,
   Stack,
   Inline,
+  ErrorState,
 } from '@/components/ui';
 
 /**
@@ -31,6 +32,9 @@ export default function ComponentsDemoPage() {
   // Modal state
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isLargeModalOpen, setIsLargeModalOpen] = useState(false);
+
+  // ErrorState trigger demo
+  const [triggeredVariant, setTriggeredVariant] = useState<string | null>(null);
 
   // Form state for inputs
   const [formData, setFormData] = useState({
@@ -405,6 +409,98 @@ export default function ComponentsDemoPage() {
                     <Badge variant="primary" isDot>Updated just now</Badge>
                   </Inline>
                 </div>
+              </Stack>
+            </CardBody>
+          </Card>
+        </Container>
+      </Section>
+
+      {/* Error State Section */}
+      <Section paddingY="lg">
+        <Container>
+          <Card>
+            <CardHeader
+              title="ErrorState Component"
+              subtitle="Consistent error UI across the app – 6 variants covering every failure scenario"
+            />
+            <CardBody>
+              <Stack gap="xl">
+
+                {/* Static showcase – all variants */}
+                <div>
+                  <h4 className="text-sm font-medium text-gray-700 mb-4">All Variants</h4>
+                  <Stack gap="md">
+                    {/* Inline */}
+                    <div>
+                      <p className="text-xs text-gray-500 mb-2 font-mono">variant="inline"</p>
+                      <ErrorState variant="inline" />
+                    </div>
+
+                    {/* Page-level variants in a grid */}
+                    <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                      {(['page', 'network', 'not-found', 'unauthorized', 'server'] as const).map(
+                        (v) => (
+                          <div key={v} className="rounded-xl border border-gray-100 dark:border-white/10 overflow-hidden">
+                            <p className="text-xs text-gray-500 font-mono px-3 pt-2 pb-1 bg-gray-50 dark:bg-white/5 border-b border-gray-100 dark:border-white/10">
+                              variant="{v}"
+                            </p>
+                            <ErrorState variant={v} />
+                          </div>
+                        )
+                      )}
+                    </div>
+                  </Stack>
+                </div>
+
+                {/* Interactive trigger demo */}
+                <div>
+                  <h4 className="text-sm font-medium text-gray-700 mb-1">Trigger Demo</h4>
+                  <p className="text-xs text-gray-500 mb-4">
+                    Click a button to simulate triggering that error state.
+                  </p>
+                  <Stack direction="row" gap="sm" wrap>
+                    {(['inline', 'page', 'network', 'not-found', 'unauthorized', 'server'] as const).map(
+                      (v) => (
+                        <Button
+                          key={v}
+                          variant={triggeredVariant === v ? 'danger' : 'outline'}
+                          size="sm"
+                          onClick={() => setTriggeredVariant(triggeredVariant === v ? null : v)}
+                        >
+                          {v}
+                        </Button>
+                      )
+                    )}
+                    {triggeredVariant && (
+                      <Button variant="ghost" size="sm" onClick={() => setTriggeredVariant(null)}>
+                        Dismiss
+                      </Button>
+                    )}
+                  </Stack>
+
+                  {triggeredVariant && (
+                    <div className="mt-4">
+                      <ErrorState
+                        variant={triggeredVariant as any}
+                        onAction={() => setTriggeredVariant(null)}
+                        onSecondaryAction={() => setTriggeredVariant(null)}
+                      />
+                    </div>
+                  )}
+                </div>
+
+                {/* Custom override example */}
+                <div>
+                  <h4 className="text-sm font-medium text-gray-700 mb-2">Custom Override</h4>
+                  <ErrorState
+                    variant="inline"
+                    title="Wallet not connected"
+                    description="Connect your Freighter wallet to continue."
+                    actionLabel="Connect wallet"
+                    onAction={() => {}}
+                  />
+                </div>
+
               </Stack>
             </CardBody>
           </Card>

--- a/harvest-finance/frontend/src/app/login/page.tsx
+++ b/harvest-finance/frontend/src/app/login/page.tsx
@@ -10,6 +10,7 @@ import { StellarAuth } from '@/components/auth/StellarAuth';
 import { EyeIcon, EyeSlashIcon } from '@/components/icons';
 import { useAuthStore } from '@/lib/stores/auth-store';
 import { loginSchema, type LoginFormData } from '@/lib/validations/auth';
+import { ErrorState } from '@/components/ui';
 
 export default function LoginPage() {
   const router = useRouter();
@@ -91,9 +92,12 @@ export default function LoginPage() {
       </div>
 
       {error ? (
-        <div className="status-banner status-banner--error mb-5" role="alert" aria-live="polite">
-          <p>{error}</p>
-        </div>
+        <ErrorState
+          variant="inline"
+          title="Sign-in failed"
+          description={error}
+          className="mb-5"
+        />
       ) : null}
 
       {authMethod === 'email' ? (

--- a/harvest-finance/frontend/src/components/ui/ErrorState/ErrorState.tsx
+++ b/harvest-finance/frontend/src/components/ui/ErrorState/ErrorState.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import React from 'react';
+import {
+  AlertCircle,
+  WifiOff,
+  FileQuestion,
+  ShieldOff,
+  ServerCrash,
+  LucideIcon,
+} from 'lucide-react';
+import { Button } from '../Button';
+import { cn } from '../types';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ErrorStateVariant =
+  | 'inline'
+  | 'page'
+  | 'network'
+  | 'not-found'
+  | 'unauthorized'
+  | 'server';
+
+export interface ErrorStateProps {
+  /** Visual variant – controls icon, colours, and layout */
+  variant?: ErrorStateVariant;
+  /** Override the default title for the variant */
+  title?: string;
+  /** Override the default description for the variant */
+  description?: string;
+  /** Primary action label */
+  actionLabel?: string;
+  /** Primary action handler */
+  onAction?: () => void;
+  /** Secondary action label (e.g. "Go home") */
+  secondaryActionLabel?: string;
+  /** Secondary action handler */
+  onSecondaryAction?: () => void;
+  /** Custom icon – overrides the variant default */
+  icon?: LucideIcon;
+  className?: string;
+}
+
+// ─── Preset config ────────────────────────────────────────────────────────────
+
+interface PresetConfig {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  actionLabel?: string;
+  secondaryActionLabel?: string;
+  /** Tailwind colour classes: [iconBg, iconColor, titleColor] */
+  colors: [string, string, string];
+}
+
+const PRESETS: Record<ErrorStateVariant, PresetConfig> = {
+  inline: {
+    icon: AlertCircle,
+    title: 'Something went wrong',
+    description: 'An unexpected error occurred. Please try again.',
+    actionLabel: 'Try again',
+    colors: ['bg-red-50 dark:bg-red-900/20', 'text-red-500', 'text-red-700 dark:text-red-400'],
+  },
+  page: {
+    icon: AlertCircle,
+    title: 'Something went wrong',
+    description: 'We encountered an unexpected error. Our team has been notified.',
+    actionLabel: 'Try again',
+    secondaryActionLabel: 'Go home',
+    colors: ['bg-red-50 dark:bg-red-900/20', 'text-red-500', 'text-gray-900 dark:text-white'],
+  },
+  network: {
+    icon: WifiOff,
+    title: 'No internet connection',
+    description: 'Check your network connection and try again.',
+    actionLabel: 'Retry',
+    colors: ['bg-amber-50 dark:bg-amber-900/20', 'text-amber-500', 'text-gray-900 dark:text-white'],
+  },
+  'not-found': {
+    icon: FileQuestion,
+    title: 'Page not found',
+    description: "The page you're looking for doesn't exist or has been moved.",
+    actionLabel: 'Go home',
+    colors: ['bg-blue-50 dark:bg-blue-900/20', 'text-blue-500', 'text-gray-900 dark:text-white'],
+  },
+  unauthorized: {
+    icon: ShieldOff,
+    title: 'Access denied',
+    description: "You don't have permission to view this page.",
+    actionLabel: 'Sign in',
+    secondaryActionLabel: 'Go home',
+    colors: ['bg-orange-50 dark:bg-orange-900/20', 'text-orange-500', 'text-gray-900 dark:text-white'],
+  },
+  server: {
+    icon: ServerCrash,
+    title: 'Server error',
+    description: 'Our servers are having trouble. Please try again in a few minutes.',
+    actionLabel: 'Try again',
+    secondaryActionLabel: 'Go home',
+    colors: ['bg-red-50 dark:bg-red-900/20', 'text-red-500', 'text-gray-900 dark:text-white'],
+  },
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function ErrorState({
+  variant = 'inline',
+  title,
+  description,
+  actionLabel,
+  onAction,
+  secondaryActionLabel,
+  onSecondaryAction,
+  icon,
+  className,
+}: ErrorStateProps) {
+  const preset = PRESETS[variant];
+  const Icon = icon ?? preset.icon;
+  const resolvedTitle = title ?? preset.title;
+  const resolvedDescription = description ?? preset.description;
+  const resolvedActionLabel = actionLabel ?? preset.actionLabel;
+  const resolvedSecondaryLabel = secondaryActionLabel ?? preset.secondaryActionLabel;
+  const [iconBg, iconColor, titleColor] = preset.colors;
+
+  const isInline = variant === 'inline';
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className={cn(
+        isInline
+          ? 'flex items-start gap-3 rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-4'
+          : 'flex flex-col items-center justify-center py-16 px-6 text-center',
+        className
+      )}
+    >
+      {/* Icon */}
+      <div
+        className={cn(
+          'flex items-center justify-center rounded-full flex-shrink-0',
+          isInline ? 'h-8 w-8' : 'mb-4 h-16 w-16',
+          iconBg
+        )}
+      >
+        <Icon
+          className={cn(isInline ? 'h-4 w-4' : 'h-8 w-8', iconColor)}
+          aria-hidden="true"
+        />
+      </div>
+
+      {/* Text */}
+      <div className={cn(isInline ? 'flex-1 min-w-0' : '')}>
+        <p
+          className={cn(
+            'font-semibold',
+            isInline ? 'text-sm' : 'text-lg mb-2',
+            titleColor
+          )}
+        >
+          {resolvedTitle}
+        </p>
+        {resolvedDescription && (
+          <p
+            className={cn(
+              'text-gray-500 dark:text-gray-400',
+              isInline ? 'text-xs mt-0.5' : 'text-sm max-w-sm mb-6'
+            )}
+          >
+            {resolvedDescription}
+          </p>
+        )}
+
+        {/* Actions */}
+        {(resolvedActionLabel || resolvedSecondaryLabel) && (
+          <div
+            className={cn(
+              'flex gap-3',
+              isInline ? 'mt-2' : 'justify-center flex-wrap'
+            )}
+          >
+            {resolvedActionLabel && onAction && (
+              <Button
+                variant={isInline ? 'ghost' : 'primary'}
+                size={isInline ? 'xs' : 'sm'}
+                onClick={onAction}
+                className={isInline ? 'text-red-700 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/40' : ''}
+              >
+                {resolvedActionLabel}
+              </Button>
+            )}
+            {resolvedSecondaryLabel && onSecondaryAction && (
+              <Button
+                variant="outline"
+                size={isInline ? 'xs' : 'sm'}
+                onClick={onSecondaryAction}
+              >
+                {resolvedSecondaryLabel}
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/harvest-finance/frontend/src/components/ui/ErrorState/index.ts
+++ b/harvest-finance/frontend/src/components/ui/ErrorState/index.ts
@@ -1,0 +1,2 @@
+export { ErrorState } from './ErrorState';
+export type { ErrorStateProps, ErrorStateVariant } from './ErrorState';

--- a/harvest-finance/frontend/src/components/ui/index.ts
+++ b/harvest-finance/frontend/src/components/ui/index.ts
@@ -116,6 +116,13 @@ export { EmptyState } from './EmptyState';
 export type { EmptyStateProps, EmptyStateVariant } from './EmptyState';
 
 // ============================================
+// Error State
+// ============================================
+
+export { ErrorState } from './ErrorState';
+export type { ErrorStateProps, ErrorStateVariant } from './ErrorState';
+
+// ============================================
 // Transaction Status
 // ============================================
 


### PR DESCRIPTION
## Summary

Implements a reusable `ErrorState` component to standardize error UI across the app, resolving #251.

Closes #251

---

## Changes

### `src/components/ui/ErrorState/ErrorState.tsx` _(new)_
Reusable component with **6 variants**:

| Variant | Layout | Icon | Colour | Use case |
|---|---|---|---|---|
| `inline` | Banner row | AlertCircle | Red | Form/API errors |
| `page` | Centered full-page | AlertCircle | Red | Unhandled exceptions |
| `network` | Centered full-page | WifiOff | Amber | Offline / fetch failed |
| `not-found` | Centered full-page | FileQuestion | Blue | 404 |
| `unauthorized` | Centered full-page | ShieldOff | Orange | 401/403 |
| `server` | Centered full-page | ServerCrash | Red | 5xx errors |

- All text/icon/action props are overridable.
- Action buttons only render when a handler is provided.
- Accessible: `role="alert"`, `aria-live="assertive"`, dark-mode support.

### `src/components/ui/ErrorState/index.ts` _(new)_
Barrel export.

### `src/components/ui/index.ts` _(updated)_
Exports `ErrorState`, `ErrorStateProps`, `ErrorStateVariant`.

### `src/app/components-demo/page.tsx` _(updated)_
Added demo section with:
- Static showcase of all 6 variants.
- Interactive trigger demo (click to simulate each error state live).
- Custom override example.

### `src/app/login/page.tsx` _(updated)_
Replaced the one-off `status-banner--error` div with `<ErrorState variant="inline" />`.

---

## Testing
- Visit `/components-demo` → scroll to **ErrorState Component** section.
- Click each variant button to trigger that error state live.
- Attempt a failed login to see the inline error banner.