### PR TITLE
docs(auth): add inline documentation for auth DTOs

### DIFF
--- a/harvest-finance/backend/src/auth/dto/auth-response.dto.ts
+++ b/harvest-finance/backend/src/auth/dto/auth-response.dto.ts
@@ -1,19 +1,23 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { UserRole } from '../../database/entities/user.entity';
 
+/** Subset of user fields returned in auth responses. Excludes sensitive data such as password hashes. */
 export class UserResponseDto {
+  /** Primary key of the user record (UUID v4). */
   @ApiProperty({
     example: '123e4567-e89b-12d3-a456-426614174000',
     description: 'User ID (UUID)',
   })
   id: string;
 
+  /** The user's registered email address. */
   @ApiProperty({
     example: 'farmer@example.com',
     description: 'User email address',
   })
   email: string;
 
+  /** The platform role that governs the user's permissions and feature access. */
   @ApiProperty({
     example: 'FARMER',
     enum: UserRole,
@@ -21,18 +25,21 @@ export class UserResponseDto {
   })
   role: UserRole;
 
+  /** The user's display name as provided during registration. */
   @ApiProperty({
     example: 'John Doe',
     description: 'User full name',
   })
   full_name: string;
 
+  /** Optional contact phone number. Null when not provided at registration. */
   @ApiPropertyOptional({
     example: '+1234567890',
     description: 'Phone number',
   })
   phone_number?: string | null;
 
+  /** The user's Stellar public key. Null when not linked to an on-chain account. */
   @ApiPropertyOptional({
     example: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
     description: 'Stellar address',
@@ -40,19 +47,23 @@ export class UserResponseDto {
   stellar_address?: string | null;
 }
 
+/** Response shape returned after a successful login or token refresh. */
 export class AuthResponseDto {
+  /** Short-lived JWT used to authenticate subsequent API requests. */
   @ApiProperty({
     example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
     description: 'Access token (JWT)',
   })
   access_token: string;
 
+  /** Long-lived JWT used to obtain a new access token without re-login. */
   @ApiProperty({
     example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
     description: 'Refresh token (JWT)',
   })
   refresh_token: string;
 
+  /** Profile data for the authenticated user. */
   @ApiProperty({
     type: UserResponseDto,
     description: 'User information',
@@ -60,7 +71,9 @@ export class AuthResponseDto {
   user: UserResponseDto;
 }
 
+/** Response shape when only a new access token is issued (e.g. after token refresh). */
 export class TokenResponseDto {
+  /** Freshly issued short-lived JWT access token. */
   @ApiProperty({
     example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
     description: 'Access token (JWT)',
@@ -68,13 +81,16 @@ export class TokenResponseDto {
   access_token: string;
 }
 
+/** Response shape returned after a successful logout. */
 export class LogoutResponseDto {
+  /** Indicates whether the server successfully invalidated the session/token. */
   @ApiProperty({
     example: true,
     description: 'Logout success status',
   })
   success: boolean;
 
+  /** Human-readable confirmation message. */
   @ApiProperty({
     example: 'Logged out successfully',
     description: 'Logout message',
@@ -82,13 +98,16 @@ export class LogoutResponseDto {
   message: string;
 }
 
+/** Generic success/failure response used for operations that return no data (e.g. forgot-password). */
 export class MessageResponseDto {
+  /** Whether the requested operation completed without error. */
   @ApiProperty({
     example: true,
     description: 'Success status',
   })
   success: boolean;
 
+  /** Human-readable description of the outcome. */
   @ApiProperty({
     example: 'Password reset link sent to your email',
     description: 'Response message',
@@ -96,22 +115,26 @@ export class MessageResponseDto {
   message: string;
 }
 
+/** Standard error envelope returned by auth endpoints on failure. */
 export class ErrorResponseDto {
+  /** HTTP status code mirrored in the body for client convenience. */
   @ApiProperty({
-    example: 'Unauthorized',
-    description: 'Error status',
+    example: 401,
+    description: 'HTTP status code',
   })
   statusCode: number;
 
+  /** Human-readable description of what went wrong. */
   @ApiProperty({
     example: 'Invalid credentials',
     description: 'Error message',
   })
   message: string;
 
+  /** Short error category string matching the HTTP status reason phrase. */
   @ApiProperty({
     example: 'Unauthorized',
-    description: 'Error error',
+    description: 'Error type',
   })
   error: string;
 }

--- a/harvest-finance/backend/src/auth/dto/forgot-password.dto.ts
+++ b/harvest-finance/backend/src/auth/dto/forgot-password.dto.ts
@@ -1,7 +1,13 @@
 import { IsEmail, IsNotEmpty } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
+/** Request body for initiating a password reset flow. */
 export class ForgotPasswordDto {
+  /**
+   * The email address associated with the account.
+   * A reset link is sent to this address if an account is found.
+   * No error is thrown when the email is not registered (prevents user enumeration).
+   */
   @ApiProperty({
     example: 'farmer@example.com',
     description: 'User email address',

--- a/harvest-finance/backend/src/auth/dto/login.dto.ts
+++ b/harvest-finance/backend/src/auth/dto/login.dto.ts
@@ -1,7 +1,12 @@
 import { IsEmail, IsString, IsNotEmpty } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
+/** Request body for the standard email/password login endpoint. */
 export class LoginDto {
+  /**
+   * The registered email address of the user.
+   * Must be a valid RFC-5321 email format.
+   */
   @ApiProperty({
     example: 'farmer@example.com',
     description: 'User email address',
@@ -10,6 +15,10 @@ export class LoginDto {
   @IsNotEmpty({ message: 'Email is required' })
   email: string;
 
+  /**
+   * The user's plaintext password.
+   * Compared against the stored bcrypt hash on the server — never stored as-is.
+   */
   @ApiProperty({
     example: 'SecurePass123!',
     description: 'User password',

--- a/harvest-finance/backend/src/auth/dto/refresh-token.dto.ts
+++ b/harvest-finance/backend/src/auth/dto/refresh-token.dto.ts
@@ -1,7 +1,13 @@
 import { IsString, IsNotEmpty } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
+/** Request body for exchanging a refresh token for a new access token. */
 export class RefreshTokenDto {
+  /**
+   * The long-lived JWT refresh token issued at login or token refresh.
+   * Used to obtain a new access token without re-authentication.
+   * Invalidated on use (rotation) or when the user logs out.
+   */
   @ApiProperty({
     example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
     description: 'Refresh token',

--- a/harvest-finance/backend/src/auth/dto/register.dto.ts
+++ b/harvest-finance/backend/src/auth/dto/register.dto.ts
@@ -11,18 +11,20 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { UserRole } from '../../database/entities/user.entity';
 
 /**
- * Password validation regex pattern
- * Requires:
- * - At least 8 characters
- * - At least one uppercase letter
- * - At least one lowercase letter
- * - At least one number
- * - At least one special character
+ * Password validation regex pattern.
+ * Requires: at least one uppercase letter, one lowercase letter,
+ * one number, and one special character (@$!%*?&).
+ * Minimum 8 characters enforced separately via @MinLength.
  */
 const PASSWORD_REGEX =
   /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]/;
 
+/** Request body for new user registration. */
 export class RegisterDto {
+  /**
+   * The user's email address. Must be unique across all accounts.
+   * Used as the primary login identifier.
+   */
   @ApiProperty({
     example: 'farmer@example.com',
     description: 'User email address (must be unique)',
@@ -31,6 +33,11 @@ export class RegisterDto {
   @IsNotEmpty({ message: 'Email is required' })
   email: string;
 
+  /**
+   * Plaintext password chosen by the user.
+   * Must be 8–32 characters and satisfy PASSWORD_REGEX complexity rules.
+   * Stored as a bcrypt hash — never persisted in plaintext.
+   */
   @ApiProperty({
     example: 'SecurePass123!',
     description:
@@ -46,6 +53,11 @@ export class RegisterDto {
   @IsNotEmpty({ message: 'Password is required' })
   password: string;
 
+  /**
+   * The platform role assigned to the new account.
+   * Determines which features and resources the user can access.
+   * Must be one of: FARMER, BUYER, INSPECTOR, ADMIN.
+   */
   @ApiProperty({
     example: 'FARMER',
     enum: UserRole,
@@ -57,6 +69,10 @@ export class RegisterDto {
   @IsNotEmpty({ message: 'Role is required' })
   role: UserRole;
 
+  /**
+   * The user's display name shown across the platform.
+   * Must be 2–100 characters.
+   */
   @ApiProperty({
     example: 'John Doe',
     description: 'Full name of the user',
@@ -67,6 +83,10 @@ export class RegisterDto {
   @IsNotEmpty({ message: 'Full name is required' })
   full_name: string;
 
+  /**
+   * Optional contact phone number including country code (e.g. +1234567890).
+   * Max 20 characters to accommodate all international formats.
+   */
   @ApiPropertyOptional({
     example: '+1234567890',
     description: 'Phone number with country code',
@@ -75,6 +95,10 @@ export class RegisterDto {
   @MaxLength(20, { message: 'Phone number must not exceed 20 characters' })
   phone_number?: string;
 
+  /**
+   * The user's Stellar blockchain public key (56-character G... address).
+   * Used to link the account to on-chain operations such as vault deposits.
+   */
   @ApiProperty({
     example: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
     description: 'Stellar blockchain address',

--- a/harvest-finance/backend/src/auth/dto/reset-password.dto.ts
+++ b/harvest-finance/backend/src/auth/dto/reset-password.dto.ts
@@ -8,12 +8,19 @@ import {
 import { ApiProperty } from '@nestjs/swagger';
 
 /**
- * Password validation regex pattern
+ * Password validation regex pattern.
+ * Requires at least one uppercase, one lowercase, one digit,
+ * and one special character (@$!%*?&).
  */
 const PASSWORD_REGEX =
   /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]/;
 
+/** Request body for completing a password reset using a reset token. */
 export class ResetPasswordDto {
+  /**
+   * The short-lived reset token delivered to the user's email by the
+   * forgot-password flow. Invalidated after a single use or expiry.
+   */
   @ApiProperty({
     example: 'abc123def456...',
     description: 'Reset token sent to user email',
@@ -22,6 +29,11 @@ export class ResetPasswordDto {
   @IsNotEmpty({ message: 'Token is required' })
   token: string;
 
+  /**
+   * The user's desired new password.
+   * Must satisfy the same complexity rules as registration (8–32 chars,
+   * upper/lower/digit/special). Replaces the existing bcrypt hash on success.
+   */
   @ApiProperty({
     example: 'NewSecurePass123!',
     description:

--- a/harvest-finance/backend/src/auth/dto/stellar-auth.dto.ts
+++ b/harvest-finance/backend/src/auth/dto/stellar-auth.dto.ts
@@ -1,7 +1,22 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
 
+/**
+ * DTOs for the SEP-10 Stellar Web Authentication flow.
+ *
+ * Flow overview:
+ *   1. Client sends its public key → server returns a challenge transaction (XDR).
+ *   2. Client signs the challenge with its Stellar secret key.
+ *   3. Client submits the signed XDR → server verifies and returns JWT tokens.
+ */
+
+/** Request body for step 1 — asking the server for a challenge transaction. */
 export class StellarChallengeDto {
+  /**
+   * The client's Stellar public key (56-character G... address).
+   * The server embeds this key into the challenge transaction so the
+   * client must sign with the corresponding secret key to prove ownership.
+   */
   @ApiProperty({
     description: 'Stellar public key of the client requesting authentication',
     example: 'GC5X3FML4S25HDAMJYZJYAC3CKLDWV2Z6YPV3IZXOSHSQKNSKUNQFXQN',
@@ -11,7 +26,13 @@ export class StellarChallengeDto {
   public_key: string;
 }
 
+/** Server response for step 1 — the unsigned challenge transaction the client must sign. */
 export class StellarChallengeResponseDto {
+  /**
+   * The server's Stellar public key.
+   * Clients should verify the challenge transaction is signed by this key
+   * before signing it themselves, to prevent man-in-the-middle attacks.
+   */
   @ApiProperty({
     description: 'Server Stellar public key for client verification',
     example: 'GCWHSK5KNLKB77NAEA3CKDKLY5GTMNKHXQRPUF6STZOD3J6VYVVZNBRV',
@@ -19,6 +40,10 @@ export class StellarChallengeResponseDto {
   @IsString()
   server_public_key: string;
 
+  /**
+   * The SEP-10 challenge transaction encoded as base64 XDR.
+   * The client must sign this with its secret key and return it in StellarVerifyDto.
+   */
   @ApiProperty({
     description: 'Challenge transaction XDR (base64 encoded)',
     example: 'AAAAAK7clQAAAA...',
@@ -27,6 +52,10 @@ export class StellarChallengeResponseDto {
   @IsNotEmpty()
   transaction: string;
 
+  /**
+   * The Stellar network passphrase used when signing the transaction.
+   * Must match the network the server operates on (mainnet or testnet).
+   */
   @ApiProperty({
     description: 'Network passphrase',
     example: 'Test SDF Network ; September 2015',
@@ -35,7 +64,13 @@ export class StellarChallengeResponseDto {
   network_passphrase: string;
 }
 
+/** Request body for step 2 — submitting the client-signed challenge transaction. */
 export class StellarVerifyDto {
+  /**
+   * The challenge transaction from StellarChallengeResponseDto, now signed
+   * by the client's Stellar secret key, encoded as base64 XDR.
+   * The server verifies the signature to confirm key ownership.
+   */
   @ApiProperty({
     description: 'Signed challenge transaction XDR (base64 encoded)',
     example: 'AAAAAK7clQAAAA...',
@@ -45,7 +80,9 @@ export class StellarVerifyDto {
   transaction: string;
 }
 
+/** Response returned after successful Stellar authentication (step 2). */
 export class StellarAuthResponseDto {
+  /** Short-lived JWT access token for authenticating subsequent API requests. */
   @ApiProperty({
     description: 'JWT access token',
     example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
@@ -53,6 +90,7 @@ export class StellarAuthResponseDto {
   @IsString()
   access_token: string;
 
+  /** Long-lived JWT refresh token used to obtain new access tokens without re-authentication. */
   @ApiProperty({
     description: 'JWT refresh token',
     example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
@@ -60,6 +98,10 @@ export class StellarAuthResponseDto {
   @IsString()
   refresh_token: string;
 
+  /**
+   * Basic profile of the authenticated user.
+   * Contains only the fields needed to identify the account on the client side.
+   */
   @ApiProperty({
     description: 'User information',
     example: {

--- a/harvest-finance/backend/src/auth/dto/stellar-auth.dto.ts
+++ b/harvest-finance/backend/src/auth/dto/stellar-auth.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
+import { IsString, IsNotEmpty } from 'class-validator';
 
 /**
  * DTOs for the SEP-10 Stellar Web Authentication flow.


### PR DESCRIPTION
## What was documented

Added JSDoc-style inline comments to all DTO classes and fields in `backend/src/auth/dto/`:

- **`login.dto.ts`** — class summary; field comments explaining email format validation and password hashing behaviour.
- **`register.dto.ts`** — field comments on uniqueness constraints, password complexity regex, role semantics, Stellar key linkage, and optional phone number format.
- **`forgot-password.dto.ts`** — explains the deliberate no-error-on-unknown-email behaviour (prevents user enumeration).
- **`reset-password.dto.ts`** — explains token single-use/expiry and new password replacement of bcrypt hash.
- **`refresh-token.dto.ts`** — clarifies token rotation on use and logout invalidation.
- **`auth-response.dto.ts`** — class-level summaries for all six response DTOs (`UserResponseDto`, `AuthResponseDto`, `TokenResponseDto`, `LogoutResponseDto`, `MessageResponseDto`, `ErrorResponseDto`) plus per-field comments.
- **`stellar-auth.dto.ts`** — added SEP-10 flow overview comment and per-field explanations for all four Stellar auth DTOs covering the challenge/verify handshake.

## Why this improves contributor experience

Contributors extending auth flows previously had to trace through validators, service logic, and Swagger UI to understand what each field represents and why constraints exist. The added comments surface that context directly at the point of declaration, reducing the time to understand and safely extend the auth module.

Fixes #271