### PR TITLE
docs(vault): add vault state transition documentation

### DIFF
--- a/harvest-finance/backend/src/database/entities/vault.entity.ts
+++ b/harvest-finance/backend/src/database/entities/vault.entity.ts
@@ -20,10 +20,53 @@ export enum VaultType {
   EMERGENCY_FUND = 'EMERGENCY_FUND',
 }
 
+/**
+ * Lifecycle states for a Vault and the valid transitions between them.
+ *
+ * State transition table:
+ * ┌────────────────┬──────────────────────────────────────────────────────────────────┐
+ * │ From           │ To (trigger)                                                     │
+ * ├────────────────┼──────────────────────────────────────────────────────────────────┤
+ * │ ACTIVE         │ → INACTIVE      (owner deactivates / vault expires at maturity)  │
+ * │ ACTIVE         │ → FROZEN        (admin freezes due to compliance or dispute)     │
+ * │ ACTIVE         │ → FULL_CAPACITY (totalDeposits >= maxCapacity, see isFullCapacity)│
+ * │ INACTIVE       │ → ACTIVE        (owner re-activates the vault)                   │
+ * │ FROZEN         │ → ACTIVE        (admin unfreezes after issue is resolved)         │
+ * │ FULL_CAPACITY  │ → ACTIVE        (a deposit is withdrawn, freeing space)           │
+ * └────────────────┴──────────────────────────────────────────────────────────────────┘
+ *
+ * ASCII diagram:
+ *
+ *                 ┌──────────────────────────────────────┐
+ *                 │                                      ▼
+ *   deactivate  INACTIVE ◄──── ACTIVE ────► FROZEN  (admin freeze)
+ *   re-activate   │              ▲  │                    │
+ *                 └──────────────┘  └──► FULL_CAPACITY   │ (admin unfreeze)
+ *                                         │              │
+ *                                         └──────────────┘
+ *                                    (withdrawal frees space)
+ *
+ * Notes:
+ *  - FULL_CAPACITY is set automatically; it is NOT a manual admin action.
+ *  - FROZEN takes precedence — a frozen vault cannot accept deposits even
+ *    if capacity is available.
+ *  - Transitions to FROZEN are always permitted regardless of current state
+ *    to allow emergency intervention.
+ */
 export enum VaultStatus {
+  /** Vault is open and accepting deposits up to maxCapacity. */
   ACTIVE = 'ACTIVE',
+
+  /** Vault has been deactivated by its owner or reached its maturityDate.
+   *  No new deposits are accepted; existing funds remain accessible. */
   INACTIVE = 'INACTIVE',
+
+  /** Vault is locked by an administrator (e.g. compliance review or dispute).
+   *  All deposit and withdrawal operations are blocked until unfrozen. */
   FROZEN = 'FROZEN',
+
+  /** totalDeposits >= maxCapacity. Set automatically by the deposit service.
+   *  Transitions back to ACTIVE once enough funds are withdrawn to free capacity. */
   FULL_CAPACITY = 'FULL_CAPACITY',
 }
 


### PR DESCRIPTION
## State transition explanation

Added a comprehensive JSDoc block to the `VaultStatus` enum in `backend/src/database/entities/vault.entity.ts` covering:

**Transition table:**

| From | To | Trigger |
|------|----|---------|
| `ACTIVE` | `INACTIVE` | Owner deactivates vault or `maturityDate` is reached |
| `ACTIVE` | `FROZEN` | Admin freezes vault (compliance / dispute) |
| `ACTIVE` | `FULL_CAPACITY` | `totalDeposits >= maxCapacity` (automatic, via deposit service) |
| `INACTIVE` | `ACTIVE` | Owner re-activates the vault |
| `FROZEN` | `ACTIVE` | Admin unfreezes after issue is resolved |
| `FULL_CAPACITY` | `ACTIVE` | A withdrawal frees enough capacity |

**ASCII diagram** showing all valid state paths is included in the comment block.

**Per-value JSDoc comments** added to each enum member explaining what the state means and which operations are blocked.

**Key invariants documented:**
- `FULL_CAPACITY` is set automatically by the deposit service — not a manual admin action.
- `FROZEN` takes precedence over all other states for deposit/withdrawal operations.
- Transitions to `FROZEN` are permitted from any state for emergency intervention.

## Why transition documentation matters

Without clear state docs, contributors risk introducing invalid state transitions (e.g. jumping from `FROZEN` directly to `FULL_CAPACITY`, or allowing deposits on a `FROZEN` vault). The inline documentation makes valid paths immediately visible at the definition site, preventing logic errors during feature extensions.

Fixes #272