### PR TITLE
docs(throttler): document throttler exception behavior

### DIFF
--- a/harvest-finance/backend/src/common/filters/throttler-exception.filter.ts
+++ b/harvest-finance/backend/src/common/filters/throttler-exception.filter.ts
@@ -6,11 +6,40 @@ import {
 } from '@nestjs/common';
 import { ThrottlerException } from '@nestjs/throttler';
 
+/**
+ * Global exception filter that intercepts ThrottlerException and converts it
+ * into a consistent HTTP 429 JSON response.
+ *
+ * Skip conditions (when this filter does NOT run):
+ *  - Any exception that is NOT a ThrottlerException passes through untouched.
+ *    The @Catch(ThrottlerException) decorator narrows scope to throttler errors only.
+ *  - Non-HTTP execution contexts (WebSocket, GraphQL, RPC) bypass this filter because
+ *    host.switchToHttp() is called unconditionally. If those transports are added
+ *    in the future, check host.getType() first and handle each context separately.
+ *
+ * Countdown / retry behavior:
+ *  - NestJS Throttler tracks the request count and TTL window internally (in-memory
+ *    or via a cache store). Once the window expires the counter resets automatically
+ *    and the client can retry — no action is required from this filter.
+ *  - This filter intentionally does NOT emit a Retry-After header. If you want clients
+ *    to know exactly how long to wait, inject ThrottlerStorage, read the remaining TTL,
+ *    and add `response.header('Retry-After', ttlSeconds)` before the .json() call.
+ *
+ * Why the exception argument is named `_`:
+ *  - ThrottlerException carries no additional metadata that changes the response shape,
+ *    so the parameter is intentionally unused. The leading underscore suppresses the
+ *    "unused variable" lint warning without disabling the rule globally.
+ */
 @Catch(ThrottlerException)
 export class ThrottlerExceptionFilter implements ExceptionFilter {
   catch(_: ThrottlerException, host: ArgumentsHost) {
+    // Assumes HTTP context. See skip conditions in the class comment above
+    // before adding WebSocket or GraphQL support.
     const response = host.switchToHttp().getResponse();
 
+    // Return a uniform 429 envelope so API consumers always see the same shape.
+    // The message is intentionally generic — avoid leaking rate-limit thresholds
+    // (e.g. "limit is 100 req/min") that could aid abuse.
     response.status(HttpStatus.TOO_MANY_REQUESTS).json({
       statusCode: HttpStatus.TOO_MANY_REQUESTS,
       error: 'Too Many Requests',

--- a/harvest-finance/backend/src/common/filters/throttler-exception.filter.ts
+++ b/harvest-finance/backend/src/common/filters/throttler-exception.filter.ts
@@ -5,6 +5,7 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { ThrottlerException } from '@nestjs/throttler';
+import { Response } from 'express';
 
 /**
  * Global exception filter that intercepts ThrottlerException and converts it
@@ -35,7 +36,7 @@ export class ThrottlerExceptionFilter implements ExceptionFilter {
   catch(_: ThrottlerException, host: ArgumentsHost) {
     // Assumes HTTP context. See skip conditions in the class comment above
     // before adding WebSocket or GraphQL support.
-    const response = host.switchToHttp().getResponse();
+    const response = host.switchToHttp().getResponse<Response>();
 
     // Return a uniform 429 envelope so API consumers always see the same shape.
     // The message is intentionally generic — avoid leaking rate-limit thresholds


### PR DESCRIPTION
## Logic clarified

Added inline comments to `backend/src/common/filters/throttler-exception.filter.ts` explaining:

**Skip conditions** (when the filter does NOT execute):
- Any exception that is not a `ThrottlerException` passes through unaffected — `@Catch(ThrottlerException)` scopes the filter to throttler errors only.
- Non-HTTP execution contexts (WebSocket, GraphQL, RPC) bypass this filter because `host.switchToHttp()` is called unconditionally; a future multi-transport expansion will need a `host.getType()` guard.

**Countdown / retry behaviour:**
- The request count and TTL window are tracked entirely by the NestJS Throttler module (in-memory or cache store). When the window expires the counter resets automatically — this filter has no involvement in that process.
- The filter intentionally omits a `Retry-After` response header. The comment explains how to add one using `ThrottlerStorage` if clients need an explicit wait time.

**Why the exception parameter is `_`:**
- `ThrottlerException` carries no extra metadata that would change the response, so the parameter is unused. The underscore convention suppresses the lint warning without a blanket disable.

**Why the message is intentionally generic:**
- Leaking rate-limit thresholds (e.g. "limit is 100 req/min") in the error message could assist abuse. The vague message is a deliberate security choice.

## Why comments were needed

The filter's behaviour is not obvious from its 10 lines of code alone. The skip conditions (decorator scope, HTTP-only assumption) and the absence of `Retry-After` are non-trivial decisions that are invisible without context, making the filter a common source of confusion during debugging and extension work.

Fixes #279