### PR TITLE
Add JSDoc comments to InputSanitizerService public methods

### DIFF
--- a/harvest-finance/backend/src/common/sanitization/input-sanitizer.service.ts
+++ b/harvest-finance/backend/src/common/sanitization/input-sanitizer.service.ts
@@ -7,7 +7,11 @@ import { Injectable, BadRequestException } from '@nestjs/common';
 @Injectable()
 export class InputSanitizerService {
   /**
-   * Validate and sanitize Stellar public key
+   * Validate and sanitize a Stellar public key.
+   *
+   * @param key - The Stellar public key to validate.
+   * @returns The trimmed Stellar public key if valid.
+   * @throws {BadRequestException} When the key is missing, not a string, or does not match the expected Stellar public key format.
    */
   validateStellarPublicKey(key: string): string {
     if (!key || typeof key !== 'string') {
@@ -25,7 +29,11 @@ export class InputSanitizerService {
   }
 
   /**
-   * Validate and sanitize contract ID
+   * Validate and sanitize a contract ID.
+   *
+   * @param id - The contract ID to validate.
+   * @returns The trimmed, lowercased contract ID if valid.
+   * @throws {BadRequestException} When the ID is missing, not a string, or is not a 56-character hex string.
    */
   validateContractId(id: string): string {
     if (!id || typeof id !== 'string') {
@@ -43,7 +51,11 @@ export class InputSanitizerService {
   }
 
   /**
-   * Validate and sanitize UUID
+   * Validate and sanitize a UUID.
+   *
+   * @param id - The UUID string to validate.
+   * @returns The trimmed, lowercased UUID if valid.
+   * @throws {BadRequestException} When the UUID is missing, not a string, or does not match UUID format.
    */
   validateUUID(id: string): string {
     if (!id || typeof id !== 'string') {
@@ -62,7 +74,11 @@ export class InputSanitizerService {
   }
 
   /**
-   * Validate and sanitize email
+   * Validate and sanitize an email address.
+   *
+   * @param email - The email address to validate.
+   * @returns The trimmed, lowercased email address if valid.
+   * @throws {BadRequestException} When the email is missing, not a string, or fails basic email validation.
    */
   validateEmail(email: string): string {
     if (!email || typeof email !== 'string') {
@@ -80,7 +96,13 @@ export class InputSanitizerService {
   }
 
   /**
-   * Validate numeric amount (prevents overflow/underflow)
+   * Validate a numeric amount and ensure it falls within bounds.
+   *
+   * @param amount - The amount to validate and convert to a number.
+   * @param min - The minimum allowed value (inclusive). Defaults to 0.
+   * @param max - The maximum allowed value (inclusive). Defaults to 1e30.
+   * @returns The validated numeric amount.
+   * @throws {BadRequestException} When the amount is not a finite number or is outside the allowed range.
    */
   validateAmount(amount: any, min: number = 0, max: number = 1e30): number {
     const num = Number(amount);
@@ -97,7 +119,12 @@ export class InputSanitizerService {
   }
 
   /**
-   * Sanitize string input (remove dangerous characters)
+   * Sanitize a string input by trimming whitespace and removing dangerous characters.
+   *
+   * @param input - The string to sanitize.
+   * @param maxLength - The maximum allowed length for the sanitized string. Defaults to 1000.
+   * @returns The sanitized string.
+   * @throws {BadRequestException} When the input is not a string or the sanitized value exceeds the maximum length.
    */
   sanitizeString(input: string, maxLength: number = 1000): string {
     if (typeof input !== 'string') {
@@ -120,7 +147,12 @@ export class InputSanitizerService {
   }
 
   /**
-   * Validate pagination parameters
+   * Validate pagination parameters and enforce safe defaults.
+   *
+   * @param skip - Number of records to skip. Defaults to 0 when omitted or invalid.
+   * @param limit - Number of records to return. Defaults to 20 when omitted and is bounded by maxLimit.
+   * @param maxLimit - The maximum allowed page size. Defaults to 100.
+   * @returns An object containing safe skip and limit values.
    */
   validatePagination(
     skip?: number,


### PR DESCRIPTION
## Summary issue #273 

Add JSDoc comments to all public methods in `InputSanitizerService`.

### What changed

- Documented parameters, return types, and thrown exceptions for:
  - `validateStellarPublicKey`
  - `validateContractId`
  - `validateUUID`
  - `validateEmail`
  - `validateAmount`
  - `sanitizeString`
  - `validatePagination`

### Why

This service is a shared backend utility used across the codebase. Clear documentation helps prevent misuse and improves developer understanding.

### Files changed

- `harvest-finance/backend/src/common/sanitization/input-sanitizer.service.ts`

Closes #273 