### PR TITLE
docs/test: resolve #281, #282, #283, #288 with capacity, realtime, and export docs and email sanitization tests

### DIFF
--- a/harvest-finance/backend/package-lock.json
+++ b/harvest-finance/backend/package-lock.json
@@ -283,7 +283,6 @@
       "resolved": "https://registry.npmjs.org/@apollo/server/-/server-5.5.1.tgz",
       "integrity": "sha512-Rn3g5TJQsMSUY23CWZTghWdBWyjX7dP1eaEBPkvmM2RHi82cDcpgTIkSCbGvtTUEGjwopLv1AAooU/n7iIZ20A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.3",
         "@apollo/server-gateway-interface": "^2.0.0",
@@ -3594,6 +3593,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/graphql/-/graphql-13.4.2.tgz",
       "integrity": "sha512-MIaMIaV9o3Tj2LsoGGwhISTZVXEIfDK8rDXplE3tSYULj6cXSY1dofOSLMF/aY+BZLwlrN4BUUowgu8qNdDZFg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@graphql-tools/merge": "9.1.9",
         "@graphql-tools/schema": "10.0.33",
@@ -8240,7 +8240,6 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },

--- a/harvest-finance/backend/src/common/sanitization/input-sanitizer.service.spec.ts
+++ b/harvest-finance/backend/src/common/sanitization/input-sanitizer.service.spec.ts
@@ -44,4 +44,40 @@ describe('InputSanitizerService', () => {
       },
     );
   });
+
+  describe('validateEmail', () => {
+    it('accepts and normalizes valid standard emails', () => {
+      expect(service.validateEmail('user@domain.com')).toBe('user@domain.com');
+      expect(service.validateEmail('  USER@domain.COM  ')).toBe('user@domain.com');
+    });
+
+    it('accepts valid internationalized and subdomain emails', () => {
+      expect(service.validateEmail('user@domain.co.uk')).toBe('user@domain.co.uk');
+      expect(service.validateEmail('user@sub.domain.company')).toBe('user@sub.domain.company');
+    });
+
+    it.each([
+      '',
+      '   ',
+      'plain-text',
+      '@domain.com',
+      'user@',
+      'user@domain',
+      'user@domain.',
+      'user @domain.com',
+      'user@ domain.com',
+      'user@domain. com',
+    ])('rejects invalid email format "%s"', (value) => {
+      expect(() => service.validateEmail(value)).toThrow(BadRequestException);
+    });
+
+    it.each([null, undefined, 1234, {}, []])(
+      'rejects non-string email value %p',
+      (value) => {
+        expect(() => service.validateEmail(value as unknown as string)).toThrow(
+          BadRequestException,
+        );
+      },
+    );
+  });
 });

--- a/harvest-finance/backend/src/export/README.md
+++ b/harvest-finance/backend/src/export/README.md
@@ -1,0 +1,33 @@
+# Export Module
+
+This module handles the aggregation and exporting of user and platform transaction data (deposits, withdrawals, and claimed rewards) in multiple formats.
+
+## Supported Formats
+
+The module supports exporting data into three formats:
+- **CSV**: Uses the `fast-csv` library. Handled by `ExportService.generateCsv(data)`.
+- **Excel**: Generates styled `.xlsx` spreadsheets using the `exceljs` library. Handled by `ExportService.generateExcel(data)`.
+- **PDF**: Generates a formatted multi-page PDF transaction report using the `pdfkit` library. Handled by `ExportService.generatePdf(data)`.
+
+## Usage
+
+The `ExportController` exposes the following endpoints for exporting transaction data (with query parameter `format` as `csv`, `excel`, or `pdf`):
+
+### User Endpoints
+- `GET /api/v1/export/users/:userId/vault/export`: Exports vault transaction data for the specified user (user/admin authorized).
+- `GET /api/v1/export/users/:userId/transactions`: Exports transaction history for the specified user (user/admin authorized).
+
+### Admin Endpoints
+- `GET /api/v1/export/admin/vault/export`: Exports aggregated vault data across all users (admin only).
+- `GET /api/v1/export/admin/transactions`: Exports all platform transactions (admin only).
+
+## How to Add New Formats
+
+To add a new export format (e.g., `JSON` or `HTML`):
+
+1. **Define the format generator in `ExportService`**:
+   Create a method (e.g., `generateJson(data: TransactionExportData[]): string`) in [export.service.ts](file:///Users/backenddevopsdeveloper/Downloads/DRIPS/mode-Harvest-Finance/harvest-finance/backend/src/export/export.service.ts).
+
+2. **Update the controller**:
+   - Update the `@ApiQuery` metadata to include the new format options in [export.controller.ts](file:///Users/backenddevopsdeveloper/Downloads/DRIPS/mode-Harvest-Finance/harvest-finance/backend/src/export/export.controller.ts).
+   - Update the controller endpoints to check for the new format, set the appropriate `Content-Type` and `Content-Disposition` headers on the Express `Response` object, and send the generated buffer/content.

--- a/harvest-finance/backend/src/realtime/realtime.gateway.ts
+++ b/harvest-finance/backend/src/realtime/realtime.gateway.ts
@@ -12,15 +12,25 @@ import { Logger, UseGuards } from '@nestjs/common';
 
 /**
  * WebSocket gateway for real-time analytics events.
+ * 
+ * Room Naming Conventions & Access Rules:
+ * ========================================================
+ * 1. Admin Room: "admin"
+ *    - Purpose: Broadcast platform-wide metrics and system alerts.
+ *    - Access Rule: Restricted to administrators. Subscribed to by clients calling 'join:admin'.
+ *    - Room Name Pattern: Exactly "admin".
  *
- * Rooms:
- *  - "admin"        → platform-wide metrics (admin only)
- *  - "farmer:<id>"  → per-farmer KPI updates
+ * 2. Farmer Room: "farmer:<id>"
+ *    - Purpose: Send targeted, farmer-specific KPI updates and alerts.
+ *    - Access Rule: Restricted to the specific farmer user.
+ *    - Room Name Pattern: "farmer:<userId>" where <userId> is the UUID of the farmer.
+ *      Subscribed to by clients who call the 'join:farmer' event with their `userId`.
+ * ========================================================
  *
  * Events emitted by server:
- *  - "metrics:platform"   → PlatformMetricsEvent
- *  - "metrics:farmer"     → FarmerMetricsEvent
- *  - "alert:threshold"    → AlertEvent
+ *  - "metrics:platform"   → PlatformMetricsEvent (sent to "admin" room)
+ *  - "metrics:farmer"     → FarmerMetricsEvent (sent to specific "farmer:<userId>" room)
+ *  - "alert:threshold"    → AlertEvent (sent to "admin" room or specific "farmer:<userId>" room)
  */
 @WebSocketGateway({
   cors: { origin: '*' },
@@ -71,7 +81,12 @@ export class RealtimeGateway
     this.server.to(`farmer:${userId}`).emit('metrics:farmer', payload);
   }
 
-  /** Broadcast an alert to a specific farmer or all admins */
+  /** 
+   * Broadcast an alert to a specific farmer or all admins.
+   * Resolves target to room:
+   *  - if target is 'admin', resolves to 'admin' room.
+   *  - otherwise, resolves to 'farmer:<target>' room.
+   */
   emitAlert(target: 'admin' | string, payload: Record<string, unknown>) {
     const room = target === 'admin' ? 'admin' : `farmer:${target}`;
     this.server.to(room).emit('alert:threshold', payload);

--- a/harvest-finance/backend/src/vaults/vaults.service.ts
+++ b/harvest-finance/backend/src/vaults/vaults.service.ts
@@ -109,6 +109,8 @@ export class VaultsService {
       throw new BadRequestException('Vault has reached maximum capacity');
     }
 
+    // Verify if the requested deposit amount is within the available capacity of the vault.
+    // The available capacity is derived from the formula: availableCapacity = maxCapacity - totalDeposits.
     if (amount > vault.availableCapacity) {
       throw new BadRequestException(
         `Deposit amount exceeds available vault capacity. Available: ${vault.availableCapacity}`,


### PR DESCRIPTION

## Summary of Changes

This PR addresses four distinct repository issues by adding key documentation and comprehensive testing:

### 1. Document RealtimeGateway Room Structure
- **Explanation**: Added a clear documentation block detailing naming conventions and access rules for the `admin` and `farmer:<id>` WebSocket rooms. Added JSDoc comments to `emitAlert` to show how targets resolve to specific rooms.
- Closes #283

### 2. Document Vault Capacity Calculation Logic
- **Explanation**: Added inline comments to the vaults service explaining how the available capacity is derived using the formula: `availableCapacity = maxCapacity - totalDeposits`.
- Closes #281

### 3. Add README to Export Module
- **Explanation**: Created a module-level `README.md` for the export service to document all supported formats (CSV, Excel, PDF), endpoint usages for users/admins, and a step-by-step extension guide for adding new export formats.
- Closes #282

### 4. Unit Tests for InputSanitizerService.validateEmail
- **Explanation**: Added a suite of 17 unit tests in the sanitization service specs, covering valid standard emails, case-insensitive/whitespace normalization, internationalized subdomains, invalid syntax patterns, and non-string types.
- Closes #288
