### PR TITLE
test/security: add tests for filters, gateway, health endpoint & remove JWT fallback secret

### DIFF
--- a/harvest-finance/backend/src/auth/strategies/jwt.strategy.ts
+++ b/harvest-finance/backend/src/auth/strategies/jwt.strategy.ts
@@ -19,11 +19,14 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     @InjectRepository(User)
     private userRepository: Repository<User>,
   ) {
+    const secret = configService.get<string>('JWT_SECRET');
+    if (!secret) {
+      throw new Error('JWT_SECRET environment variable is not set');
+    }
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey:
-        configService.get<string>('JWT_SECRET') || 'super_secret_jwt_key',
+      secretOrKey: secret,
     });
   }
 

--- a/harvest-finance/backend/src/common/filters/http-exception.filter.spec.ts
+++ b/harvest-finance/backend/src/common/filters/http-exception.filter.spec.ts
@@ -1,0 +1,87 @@
+import { HttpException, HttpStatus, ArgumentsHost } from '@nestjs/common';
+import { HttpExceptionFilter } from './http-exception.filter';
+import { CustomLoggerService } from '../../logger/custom-logger.service';
+
+const mockJson = jest.fn();
+const mockStatus = jest.fn().mockReturnValue({ json: mockJson });
+const mockGetResponse = jest.fn().mockReturnValue({ status: mockStatus });
+const mockGetRequest = jest.fn().mockReturnValue({ url: '/test', method: 'GET' });
+
+const mockHost = {
+  switchToHttp: () => ({
+    getResponse: mockGetResponse,
+    getRequest: mockGetRequest,
+  }),
+} as unknown as ArgumentsHost;
+
+const mockLogger = {
+  error: jest.fn(),
+} as unknown as CustomLoggerService;
+
+describe('HttpExceptionFilter', () => {
+  let filter: HttpExceptionFilter;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    filter = new HttpExceptionFilter(mockLogger);
+  });
+
+  it('maps HttpException to its status code and string message', () => {
+    filter.catch(new HttpException('Not found', HttpStatus.NOT_FOUND), mockHost);
+
+    expect(mockStatus).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+    expect(mockJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: HttpStatus.NOT_FOUND,
+        message: 'Not found',
+        path: '/test',
+        method: 'GET',
+      }),
+    );
+  });
+
+  it('maps HttpException with object response to message field', () => {
+    filter.catch(
+      new HttpException({ message: 'Validation failed', error: 'Bad Request' }, HttpStatus.BAD_REQUEST),
+      mockHost,
+    );
+
+    expect(mockStatus).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+    expect(mockJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: 'Validation failed',
+      }),
+    );
+  });
+
+  it('maps generic Error to 500 with "Internal server error"', () => {
+    filter.catch(new Error('Something broke'), mockHost);
+
+    expect(mockStatus).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
+    expect(mockJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+        message: 'Internal server error',
+      }),
+    );
+  });
+
+  it('maps non-Error unknown throws to 500', () => {
+    filter.catch('unexpected string throw', mockHost);
+
+    expect(mockStatus).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
+    expect(mockJson).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: HttpStatus.INTERNAL_SERVER_ERROR }),
+    );
+  });
+
+  it('includes timestamp, path, and method in every response', () => {
+    filter.catch(new HttpException('Forbidden', HttpStatus.FORBIDDEN), mockHost);
+
+    const payload = mockJson.mock.calls[0][0];
+    expect(payload.timestamp).toBeDefined();
+    expect(payload.path).toBe('/test');
+    expect(payload.method).toBe('GET');
+  });
+});

--- a/harvest-finance/backend/src/realtime/realtime.gateway.spec.ts
+++ b/harvest-finance/backend/src/realtime/realtime.gateway.spec.ts
@@ -1,0 +1,46 @@
+import { RealtimeGateway } from './realtime.gateway';
+
+const mockEmit = jest.fn();
+const mockTo = jest.fn().mockReturnValue({ emit: mockEmit });
+
+describe('RealtimeGateway – alert broadcasting', () => {
+  let gateway: RealtimeGateway;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    gateway = new RealtimeGateway();
+    gateway.server = { to: mockTo } as any;
+  });
+
+  describe('emitAlert', () => {
+    it('sends to "admin" room when target is "admin"', () => {
+      const payload = { message: 'threshold exceeded' };
+      gateway.emitAlert('admin', payload);
+
+      expect(mockTo).toHaveBeenCalledWith('admin');
+      expect(mockEmit).toHaveBeenCalledWith('alert:threshold', payload);
+    });
+
+    it('sends to "farmer:<id>" room when target is a farmer id', () => {
+      const payload = { message: 'low balance' };
+      gateway.emitAlert('farmer-42', payload);
+
+      expect(mockTo).toHaveBeenCalledWith('farmer:farmer-42');
+      expect(mockEmit).toHaveBeenCalledWith('alert:threshold', payload);
+    });
+
+    it('does NOT broadcast admin alerts to farmer rooms', () => {
+      gateway.emitAlert('admin', { message: 'admin only' });
+
+      const room: string = mockTo.mock.calls[0][0];
+      expect(room).not.toMatch(/^farmer:/);
+    });
+
+    it('does NOT broadcast farmer alerts to admin room', () => {
+      gateway.emitAlert('farmer-7', { message: 'farmer only' });
+
+      const room: string = mockTo.mock.calls[0][0];
+      expect(room).not.toBe('admin');
+    });
+  });
+});

--- a/harvest-finance/backend/test/stellar-health.e2e-spec.ts
+++ b/harvest-finance/backend/test/stellar-health.e2e-spec.ts
@@ -1,0 +1,44 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { StellarController } from '../src/stellar/stellar.controller';
+import { StellarService } from '../src/stellar/services/stellar.service';
+
+describe('GET /stellar/health (e2e)', () => {
+  let app: INestApplication;
+  const mockStellarService = { verifyConnection: jest.fn() };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [StellarController],
+      providers: [{ provide: StellarService, useValue: mockStellarService }],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(() => app.close());
+
+  it('returns connected:true when Stellar server is reachable', async () => {
+    mockStellarService.verifyConnection.mockResolvedValue(true);
+
+    const { body } = await request(app.getHttpServer())
+      .get('/stellar/health')
+      .expect(200);
+
+    expect(body.connected).toBe(true);
+    expect(body.timestamp).toBeDefined();
+  });
+
+  it('returns connected:false when Stellar server is unreachable', async () => {
+    mockStellarService.verifyConnection.mockResolvedValue(false);
+
+    const { body } = await request(app.getHttpServer())
+      .get('/stellar/health')
+      .expect(200);
+
+    expect(body.connected).toBe(false);
+    expect(body.timestamp).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

This PR resolves four issues across the testing and security areas.

---

### #297 – Unit tests for `HttpExceptionFilter` error mapping
**File:** `backend/src/common/filters/http-exception.filter.spec.ts`

Added 5 unit tests verifying the filter maps exceptions to the correct response shape:
- `HttpException` with a string message → correct status code + message
- `HttpException` with an object response → extracts the `.message` field
- Generic `Error` → 500 + `"Internal server error"`
- Non-Error unknown throw → 500
- Every response includes `timestamp`, `path`, and `method`

---

### #298 – Unit tests for `RealtimeGateway` alert broadcasting
**File:** `backend/src/realtime/realtime.gateway.spec.ts`

Added 4 unit tests verifying alerts are routed to the correct Socket.io room:
- Target `"admin"` → emits to the `admin` room
- Target farmer ID → emits to the `farmer:<id>` room
- Admin alerts never leak into farmer rooms
- Farmer alerts never leak into the admin room

---

### #299 – E2E tests for Stellar health endpoint
**File:** `backend/test/stellar-health.e2e-spec.ts`

Added 2 E2E tests for `GET /stellar/health` using a mocked `StellarService`:
- Healthy Stellar server → `{ connected: true, timestamp }` with HTTP 200
- Unreachable Stellar server → `{ connected: false, timestamp }` with HTTP 200

---

### #300 – Remove hardcoded JWT fallback secret
**File:** `backend/src/auth/strategies/jwt.strategy.ts`

Replaced the `|| 'super_secret_jwt_key'` fallback with an explicit startup error:
```
Error: JWT_SECRET environment variable is not set
```
The application now fails fast if `JWT_SECRET` is missing, preventing accidental use of a known insecure secret in production.

---

Closes #297
Closes #298
Closes #299
Closes #300