### PR TITLE
dx: add devcontainer, vscode snippets, Makefile, and conventional commits docs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+{
+  "name": "Harvest Finance",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "backend",
+  "workspaceFolder": "/workspace",
+  "overrideCommand": false,
+  "forwardPorts": [3000, 3001, 5432, 6379],
+  "portsAttributes": {
+    "3001": { "label": "Backend API" },
+    "3000": { "label": "Frontend" },
+    "5432": { "label": "PostgreSQL" },
+    "6379": { "label": "Redis" }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22"
+    },
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "firsttris.vscode-jest-runner",
+        "ms-azuretools.vscode-docker",
+        "ms-vscode.vscode-typescript-next",
+        "ckolkman.vscode-postgres"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "typescript.preferences.importModuleSpecifier": "relative"
+      }
+    }
+  },
+  "postCreateCommand": "cd harvest-finance/backend && npm install",
+  "remoteUser": "node"
+}

--- a/.vscode/snippets/nestjs.code-snippets
+++ b/.vscode/snippets/nestjs.code-snippets
@@ -1,0 +1,78 @@
+{
+  "ApiProperty decorator": {
+    "prefix": "apiprop",
+    "body": [
+      "@ApiProperty({ description: '$1', example: $2 })",
+      "$0"
+    ],
+    "description": "NestJS @ApiProperty decorator with description and example"
+  },
+  "ApiPropertyOptional decorator": {
+    "prefix": "apiopt",
+    "body": [
+      "@ApiPropertyOptional({ description: '$1', example: $2 })",
+      "$0"
+    ],
+    "description": "NestJS @ApiPropertyOptional decorator"
+  },
+  "CreateDto class": {
+    "prefix": "createdto",
+    "body": [
+      "import { ApiProperty } from '@nestjs/swagger';",
+      "import { IsString, IsNotEmpty } from 'class-validator';",
+      "",
+      "export class Create${1:Resource}Dto {",
+      "  @ApiProperty({ description: '$2', example: '$3' })",
+      "  @IsString()",
+      "  @IsNotEmpty()",
+      "  ${4:field}: string;",
+      "$0",
+      "}"
+    ],
+    "description": "NestJS CreateDto class with ApiProperty and class-validator decorators"
+  },
+  "UpdateDto class": {
+    "prefix": "updatedto",
+    "body": [
+      "import { ApiPropertyOptional, PartialType } from '@nestjs/swagger';",
+      "import { Create${1:Resource}Dto } from './create-${2:resource}.dto';",
+      "",
+      "export class Update${1:Resource}Dto extends PartialType(Create${1:Resource}Dto) {}"
+    ],
+    "description": "NestJS UpdateDto extending PartialType of the CreateDto"
+  },
+  "IsString validator": {
+    "prefix": "isstr",
+    "body": [
+      "@IsString()",
+      "@IsNotEmpty()",
+      "$0"
+    ],
+    "description": "class-validator @IsString and @IsNotEmpty decorators"
+  },
+  "IsNumber validator": {
+    "prefix": "isnum",
+    "body": [
+      "@IsNumber()",
+      "@Min($1)",
+      "$0"
+    ],
+    "description": "class-validator @IsNumber and @Min decorators"
+  },
+  "IsOptional validator": {
+    "prefix": "isopt",
+    "body": [
+      "@IsOptional()",
+      "$0"
+    ],
+    "description": "class-validator @IsOptional decorator"
+  },
+  "IsEnum validator": {
+    "prefix": "isenum",
+    "body": [
+      "@IsEnum(${1:EnumName})",
+      "$0"
+    ],
+    "description": "class-validator @IsEnum decorator"
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,14 +65,67 @@ Always branch off `main` unless the issue specifies otherwise.
 
 ## Commit Messages
 
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
+This project follows the [Conventional Commits](https://www.conventionalcommits.org/) specification. Every commit message must use the format below so that changelogs can be generated automatically.
+
+### Format
 
 ```
-feat: add analytics dashboard endpoint
-fix: correct vault totalDeposits drift on withdrawal
+<type>[optional scope]: <short description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+- **type** — one of the allowed values listed below (lowercase, required)
+- **scope** — the area of the codebase affected, in parentheses, e.g. `auth`, `vault`, `dto` (optional)
+- **short description** — imperative, present tense, no trailing period, max 72 chars
+- **body** — free-form text explaining *why* the change was made (optional)
+- **footer** — `BREAKING CHANGE: <description>` or issue references such as `Closes #123` (optional)
+
+### Allowed types
+
+| Type | When to use |
+|---|---|
+| `feat` | A new feature visible to users or API consumers |
+| `fix` | A bug fix |
+| `docs` | Documentation changes only |
+| `test` | Adding or updating tests, no production code change |
+| `refactor` | Code restructuring with no feature or bug-fix impact |
+| `chore` | Tooling, dependencies, config, CI — nothing that affects runtime |
+| `perf` | A change that improves performance |
+| `style` | Formatting, whitespace — no logic change |
+| `build` | Build system or external dependency updates |
+| `ci` | CI/CD configuration changes |
+
+### Examples
+
+```
+feat(auth): add Stellar wallet login endpoint
+
+fix(vault): correct totalDeposits drift on withdrawal
+
 docs: update API README with state-sync endpoints
-test: add fuzz tests for VaultLib.toShares
-refactor: extract share math into VaultLib
+
+test(vault): add fuzz tests for VaultLib.toShares
+
+refactor(vault): extract share math into VaultLib
+
+chore: upgrade TypeORM to 0.3.28
+
+feat(api)!: rename /deposits to /farm-vaults/deposits
+
+BREAKING CHANGE: the /deposits route has been removed; update all clients to use /farm-vaults/deposits
+```
+
+### Breaking changes
+
+Append `!` after the type/scope and add a `BREAKING CHANGE:` footer:
+
+```
+feat(api)!: rename deposit response fields
+
+BREAKING CHANGE: `amount_deposited` is now `principal`; update all API clients accordingly
 ```
 
 Reference the issue number in the PR description with `Closes #<issue>`.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,79 @@
+BACKEND_DIR := harvest-finance/backend
+FRONTEND_DIR := harvest-finance/frontend
+
+.PHONY: help dev build test lint format \
+        db:migrate db:migrate:revert db:seed db:seed:clear db:seed:reset \
+        docker:up docker:down docker:logs
+
+help:
+	@grep -E '^[a-zA-Z_:/-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
+
+## ── Development ────────────────────────────────────────────────────────────────
+
+dev: ## Start backend in watch mode
+	cd $(BACKEND_DIR) && npm run start:dev
+
+dev:frontend: ## Start frontend dev server
+	cd $(FRONTEND_DIR) && npm run dev
+
+dev:all: ## Start all services via Docker Compose
+	docker compose up -d
+
+## ── Build ───────────────────────────────────────────────────────────────────
+
+build: ## Build the backend
+	cd $(BACKEND_DIR) && npm run build
+
+build:frontend: ## Build the frontend
+	cd $(FRONTEND_DIR) && npm run build
+
+## ── Code quality ────────────────────────────────────────────────────────────
+
+lint: ## Lint and auto-fix backend source
+	cd $(BACKEND_DIR) && npm run lint
+
+format: ## Format backend source with Prettier
+	cd $(BACKEND_DIR) && npm run format
+
+## ── Tests ───────────────────────────────────────────────────────────────────
+
+test: ## Run backend unit tests
+	cd $(BACKEND_DIR) && npm run test
+
+test:cov: ## Run backend unit tests with coverage report
+	cd $(BACKEND_DIR) && npm run test:cov
+
+test:e2e: ## Run backend end-to-end tests
+	cd $(BACKEND_DIR) && npm run test:e2e
+
+test:watch: ## Run backend unit tests in watch mode
+	cd $(BACKEND_DIR) && npm run test:watch
+
+## ── Database ────────────────────────────────────────────────────────────────
+
+db:migrate: ## Run pending TypeORM migrations
+	cd $(BACKEND_DIR) && npm run migration:run
+
+db:migrate:revert: ## Revert the last TypeORM migration
+	cd $(BACKEND_DIR) && npm run migration:revert
+
+db:seed: ## Seed the database with initial data
+	cd $(BACKEND_DIR) && npm run seed
+
+db:seed:clear: ## Clear all seeded data from the database
+	cd $(BACKEND_DIR) && npm run seed:clear
+
+db:seed:reset: ## Clear and re-seed the database
+	cd $(BACKEND_DIR) && npm run seed:reset
+
+## ── Docker ──────────────────────────────────────────────────────────────────
+
+docker:up: ## Start all Docker Compose services in the background
+	docker compose up -d
+
+docker:down: ## Stop and remove all Docker Compose services
+	docker compose down
+
+docker:logs: ## Tail logs for all running Docker Compose services
+	docker compose logs -f


### PR DESCRIPTION
## Summary

This PR resolves four developer-experience issues by adding tooling and documentation that lower onboarding friction and improve day-to-day contributor workflow.

### Changes

**`.devcontainer/devcontainer.json`** (closes #389)
Adds a GitHub Codespaces devcontainer configuration. It reuses the existing `docker-compose.yml` (which already defines PostgreSQL 16 and Redis 7 services) as the Compose file, forwards all relevant ports (3000, 3001, 5432, 6379), installs the Node.js 22 feature, and pre-installs recommended VS Code extensions (ESLint, Prettier, Jest Runner, Docker, Postgres client). `postCreateCommand` runs `npm install` inside the backend so the environment is ready immediately after the container starts.

**`.vscode/snippets/nestjs.code-snippets`** (closes #390)
Adds eight editor snippets covering the most common NestJS DTO boilerplate: `@ApiProperty`, `@ApiPropertyOptional`, `CreateDto` class, `UpdateDto` class (via `PartialType`), and `class-validator` decorators (`@IsString`, `@IsNumber`, `@IsOptional`, `@IsEnum`). Snippet prefixes are short and memorable (`apiprop`, `createdto`, `updatedto`, etc.).

**`Makefile`** (closes #391)
Adds a root-level `Makefile` with self-documenting targets grouped by concern:
- **Development** — `make dev`, `make dev:frontend`, `make dev:all`
- **Build** — `make build`, `make build:frontend`
- **Code quality** — `make lint`, `make format`
- **Tests** — `make test`, `make test:cov`, `make test:e2e`, `make test:watch`
- **Database** — `make db:migrate`, `make db:migrate:revert`, `make db:seed`, `make db:seed:clear`, `make db:seed:reset`
- **Docker** — `make docker:up`, `make docker:down`, `make docker:logs`

All targets delegate to the npm scripts already defined in `harvest-finance/backend/package.json`, so there is no duplication of logic.

**`CONTRIBUTING.md`** (closes #392)
Expands the existing "Commit Messages" section with the full Conventional Commits format specification: message structure, a table of all allowed types (including `chore:`, `perf:`, `style:`, `build:`, `ci:`), concrete examples with and without scope, and guidance on how to mark breaking changes with `!` and a `BREAKING CHANGE:` footer. No other sections of `CONTRIBUTING.md` were modified.

## Test plan

- [ ] Open the repository in GitHub Codespaces and verify the container builds and the backend starts without manual intervention
- [ ] Confirm the VS Code snippet prefix `createdto` expands correctly in a `.ts` file
- [ ] Run `make test` and `make lint` locally and verify they delegate to the correct backend npm scripts
- [ ] Read the updated `CONTRIBUTING.md` commit-message section and confirm all type examples render correctly
