### PR TITLE
feat: emit domain events for deposits, withdrawals, and escrow

### DIFF
--- a/PR_DESCRIPTION_382.md
+++ b/PR_DESCRIPTION_382.md
@@ -1,0 +1,36 @@
+## Summary
+Adds typed domain events for vault deposits, vault withdrawals, and escrow lifecycle changes using NestJS `EventEmitter2`.
+
+## Purpose / Motivation
+Event-driven side effects are easier to test and extend than scattering direct service calls. Downstream features (analytics, notifications, audit logs) can subscribe with `@OnEvent` without modifying core vault or Stellar flows.
+
+## Changes Made
+- Introduced `DomainEventsModule` (global) with event name constants and typed payloads:
+  - `DepositCompletedEvent` (`vault.deposit.completed`)
+  - `WithdrawalCompletedEvent` (`vault.withdrawal.completed`)
+  - `EscrowChangedEvent` (`escrow.changed`) with actions `created`, `released`, `refunded`
+- `VaultsService` emits deposit/withdrawal events after successful confirmation
+- `OrdersService` emits escrow events when orders enter escrow or upfront payment is released
+- `StellarService` emits escrow events on create, release, and refund
+- Unit test mocks updated for `EventEmitter2` injection
+
+## How to Test
+1. Run backend unit tests: `cd harvest-finance/backend && npm test`
+2. Deposit to a vault via API; add a temporary `@OnEvent(DomainEventNames.DEPOSIT_COMPLETED)` handler and confirm payload includes `depositId`, `userId`, `vaultId`, and `amount`
+3. Withdraw from a vault; confirm `vault.withdrawal.completed` fires with matching withdrawal id
+4. Accept an order (escrow created) or call Stellar escrow endpoints; confirm `escrow.changed` events with the expected `action`
+
+## Screenshots (if applicable)
+N/A — backend-only change.
+
+## Breaking Changes
+- None. Existing WebSocket and notification behavior is unchanged; events are additive.
+
+## Related Issues
+Closes code-flexing/Harvest-Finance#382
+
+## Checklist
+- [x] Code builds successfully
+- [x] Tests added/updated
+- [x] No console errors
+- [ ] Documentation updated (if needed)

--- a/harvest-finance/backend/src/app.module.ts
+++ b/harvest-finance/backend/src/app.module.ts
@@ -76,10 +76,12 @@ import { AddInsuranceNotificationType1700000000010 } from './database/migrations
 import { CreateSorobanEvents1700000000011 } from './database/migrations/1700000000011-CreateSorobanEvents';
 import { CreateYieldAnalytics1700000000012 } from './database/migrations/1700000000012-CreateYieldAnalytics';
 import { AddSorobanEventQueryIndexes1700000000013 } from './database/migrations/1700000000013-AddSorobanEventQueryIndexes';
+import { DomainEventsModule } from './domain-events';
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
+    DomainEventsModule,
     ThrottlerModule.forRootAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/harvest-finance/backend/src/domain-events/domain-event-names.ts
+++ b/harvest-finance/backend/src/domain-events/domain-event-names.ts
@@ -1,0 +1,8 @@
+export const DomainEventNames = {
+  DEPOSIT_COMPLETED: 'vault.deposit.completed',
+  WITHDRAWAL_COMPLETED: 'vault.withdrawal.completed',
+  ESCROW_CHANGED: 'escrow.changed',
+} as const;
+
+export type DomainEventName =
+  (typeof DomainEventNames)[keyof typeof DomainEventNames];

--- a/harvest-finance/backend/src/domain-events/domain-events.module.ts
+++ b/harvest-finance/backend/src/domain-events/domain-events.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { EventEmitterModule } from '@nestjs/event-emitter';
+
+@Global()
+@Module({
+  imports: [EventEmitterModule.forRoot()],
+  exports: [EventEmitterModule],
+})
+export class DomainEventsModule {}

--- a/harvest-finance/backend/src/domain-events/events/deposit-completed.event.ts
+++ b/harvest-finance/backend/src/domain-events/events/deposit-completed.event.ts
@@ -1,0 +1,11 @@
+export class DepositCompletedEvent {
+  constructor(
+    public readonly depositId: string,
+    public readonly userId: string,
+    public readonly vaultId: string,
+    public readonly amount: number,
+    public readonly vaultName: string,
+    public readonly newBalance: number,
+    public readonly occurredAt: Date = new Date(),
+  ) {}
+}

--- a/harvest-finance/backend/src/domain-events/events/escrow-changed.event.ts
+++ b/harvest-finance/backend/src/domain-events/events/escrow-changed.event.ts
@@ -1,0 +1,12 @@
+export type EscrowChangeAction = 'created' | 'released' | 'refunded';
+
+export class EscrowChangedEvent {
+  constructor(
+    public readonly action: EscrowChangeAction,
+    public readonly orderId: string,
+    public readonly transactionHash?: string,
+    public readonly balanceId?: string,
+    public readonly amount?: string,
+    public readonly occurredAt: Date = new Date(),
+  ) {}
+}

--- a/harvest-finance/backend/src/domain-events/events/withdrawal-completed.event.ts
+++ b/harvest-finance/backend/src/domain-events/events/withdrawal-completed.event.ts
@@ -1,0 +1,11 @@
+export class WithdrawalCompletedEvent {
+  constructor(
+    public readonly withdrawalId: string,
+    public readonly userId: string,
+    public readonly vaultId: string,
+    public readonly amount: number,
+    public readonly vaultName: string,
+    public readonly newBalance: number,
+    public readonly occurredAt: Date = new Date(),
+  ) {}
+}

--- a/harvest-finance/backend/src/domain-events/index.ts
+++ b/harvest-finance/backend/src/domain-events/index.ts
@@ -1,8 +1,6 @@
 export { DomainEventNames } from './domain-event-names';
 export { DepositCompletedEvent } from './events/deposit-completed.event';
 export { WithdrawalCompletedEvent } from './events/withdrawal-completed.event';
-export {
-  EscrowChangedEvent,
-  EscrowChangeAction,
-} from './events/escrow-changed.event';
+export { EscrowChangedEvent } from './events/escrow-changed.event';
+export type { EscrowChangeAction } from './events/escrow-changed.event';
 export { DomainEventsModule } from './domain-events.module';

--- a/harvest-finance/backend/src/domain-events/index.ts
+++ b/harvest-finance/backend/src/domain-events/index.ts
@@ -1,0 +1,8 @@
+export { DomainEventNames } from './domain-event-names';
+export { DepositCompletedEvent } from './events/deposit-completed.event';
+export { WithdrawalCompletedEvent } from './events/withdrawal-completed.event';
+export {
+  EscrowChangedEvent,
+  EscrowChangeAction,
+} from './events/escrow-changed.event';
+export { DomainEventsModule } from './domain-events.module';

--- a/harvest-finance/backend/src/orders/orders.service.spec.ts
+++ b/harvest-finance/backend/src/orders/orders.service.spec.ts
@@ -4,6 +4,7 @@ import { OrdersRepository } from './orders.repository';
 import { StellarService } from './stellar.service';
 import { CreateOrderDto } from './dto/create-order.dto';
 import { OrderStatus } from './order-status.enum';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 describe('OrdersService', () => {
   let service: OrdersService;
@@ -12,7 +13,12 @@ describe('OrdersService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [OrdersService, OrdersRepository, StellarService],
+      providers: [
+        OrdersService,
+        OrdersRepository,
+        StellarService,
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
+      ],
     }).compile();
 
     service = module.get<OrdersService>(OrdersService);

--- a/harvest-finance/backend/src/orders/orders.service.ts
+++ b/harvest-finance/backend/src/orders/orders.service.ts
@@ -9,12 +9,15 @@ import { CreateOrderDto } from './dto/create-order.dto';
 import { OrderEntity } from './entities/order.entity';
 import { OrderStatus } from './order-status.enum';
 import { StellarService } from './stellar.service';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { DomainEventNames, EscrowChangedEvent } from '../domain-events';
 
 @Injectable()
 export class OrdersService {
   constructor(
     private repo: OrdersRepository,
     private stellar: StellarService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async create(
@@ -65,6 +68,18 @@ export class OrdersService {
       order.escrowTxHash = escrowTx;
       order.status = OrderStatus.IN_ESCROW;
       await this.repo.save(order);
+
+      this.eventEmitter.emit(
+        DomainEventNames.ESCROW_CHANGED,
+        new EscrowChangedEvent(
+          'created',
+          order.id,
+          escrowTx,
+          undefined,
+          String(order.price * order.quantity),
+        ),
+      );
+
       return order;
     } catch (err) {
       // rollback acceptance
@@ -96,6 +111,18 @@ export class OrdersService {
     order.status = OrderStatus.ACCEPTED;
     order.escrowTxHash = tx.transactionHash;
     await this.repo.save(order);
+
+    this.eventEmitter.emit(
+      DomainEventNames.ESCROW_CHANGED,
+      new EscrowChangedEvent(
+        'released',
+        order.id,
+        tx.transactionHash,
+        undefined,
+        upfrontAmount,
+      ),
+    );
+
     return order;
   }
 }

--- a/harvest-finance/backend/src/stellar/services/stellar.service.spec.ts
+++ b/harvest-finance/backend/src/stellar/services/stellar.service.spec.ts
@@ -8,6 +8,7 @@ import {
   BadRequestException,
   InternalServerErrorException,
 } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 describe('StellarService - Escrow Creation', () => {
   let service: StellarService;
@@ -70,6 +71,7 @@ describe('StellarService - Escrow Creation', () => {
             debug: jest.fn(),
           },
         },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
       ],
     }).compile();
 

--- a/harvest-finance/backend/src/stellar/services/stellar.service.ts
+++ b/harvest-finance/backend/src/stellar/services/stellar.service.ts
@@ -9,6 +9,12 @@ import { ConfigService } from '@nestjs/config';
 import { SecretsService } from '../../common/secrets/secrets.service';
 import * as StellarSdk from 'stellar-sdk';
 import { CustomLoggerService } from '../../logger/custom-logger.service';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import {
+  DomainEventNames,
+  EscrowChangeAction,
+  EscrowChangedEvent,
+} from '../../domain-events';
 import {
   EscrowCreateParams,
   EscrowResult,
@@ -37,6 +43,7 @@ export class StellarService implements OnModuleInit {
     private readonly configService: ConfigService,
     private readonly secretsService: SecretsService,
     customLogger: CustomLoggerService,
+    private readonly eventEmitter: EventEmitter2,
   ) {
     this.structuredLogger = customLogger;
     const network = this.configService.get<string>(
@@ -496,7 +503,7 @@ export class StellarService implements OnModuleInit {
         .call();
       const balanceId = this.extractBalanceId(response as any);
 
-      return {
+      const escrowResult: EscrowResult = {
         balanceId,
         transactionHash: bumpResult.innerTransactionHash,
         feeBumpTransactionHash: bumpResult.feeBumpTransactionHash,
@@ -508,6 +515,13 @@ export class StellarService implements OnModuleInit {
         buyerPublicKey,
         orderId,
       };
+      this.emitEscrowChanged('created', {
+        orderId: escrowResult.orderId,
+        transactionHash: escrowResult.transactionHash,
+        balanceId: escrowResult.balanceId,
+        amount: escrowResult.amount,
+      });
+      return escrowResult;
     }
 
     try {
@@ -518,7 +532,7 @@ export class StellarService implements OnModuleInit {
         `Escrow created | balanceId=${balanceId} txHash=${response.hash}`,
       );
 
-      return {
+      const escrowResult: EscrowResult = {
         balanceId,
         transactionHash: response.hash,
         createdAt: new Date(),
@@ -529,6 +543,13 @@ export class StellarService implements OnModuleInit {
         buyerPublicKey,
         orderId,
       };
+      this.emitEscrowChanged('created', {
+        orderId: escrowResult.orderId,
+        transactionHash: escrowResult.transactionHash,
+        balanceId: escrowResult.balanceId,
+        amount: escrowResult.amount,
+      });
+      return escrowResult;
     } catch (err) {
       this.handleStellarError(err, 'createEscrow');
     }
@@ -580,13 +601,19 @@ export class StellarService implements OnModuleInit {
         this.platformSecretKey, // Platform pays the bump fee to ensure release
         params.priorityFeeStroops,
       );
-      return {
+      const releaseStatus: TransactionStatus = {
         transactionHash: bumpResult.innerTransactionHash,
         status: 'success',
         ledger: bumpResult.ledger,
         createdAt: bumpResult.createdAt,
         fee: bumpResult.feeCharged,
       };
+      this.emitEscrowChanged('released', {
+        orderId: params.balanceId,
+        transactionHash: releaseStatus.transactionHash,
+        balanceId: params.balanceId,
+      });
+      return releaseStatus;
     }
 
     try {
@@ -596,13 +623,19 @@ export class StellarService implements OnModuleInit {
       );
       this.logger.log(`Payment released | txHash=${response.hash}`);
 
-      return {
+      const releaseStatus: TransactionStatus = {
         transactionHash: response.hash,
         status: 'success',
         ledger: response.ledger,
         createdAt: new Date(),
         fee: '0',
       };
+      this.emitEscrowChanged('released', {
+        orderId: params.balanceId,
+        transactionHash: releaseStatus.transactionHash,
+        balanceId: params.balanceId,
+      });
+      return releaseStatus;
     } catch (err) {
       this.handleStellarError(err, 'releasePayment');
     }
@@ -652,26 +685,38 @@ export class StellarService implements OnModuleInit {
         this.platformSecretKey, // Platform pays the bump fee to ensure refund
         params.priorityFeeStroops,
       );
-      return {
+      const refundStatus: TransactionStatus = {
         transactionHash: bumpResult.innerTransactionHash,
         status: 'success',
         ledger: bumpResult.ledger,
         createdAt: bumpResult.createdAt,
         fee: bumpResult.feeCharged,
       };
+      this.emitEscrowChanged('refunded', {
+        orderId: params.balanceId,
+        transactionHash: refundStatus.transactionHash,
+        balanceId: params.balanceId,
+      });
+      return refundStatus;
     }
 
     try {
       const response = await this.submitWithRetry(transaction, 'refund');
       this.logger.log(`Refund processed | txHash=${response.hash}`);
 
-      return {
+      const refundStatus: TransactionStatus = {
         transactionHash: response.hash,
         status: 'success',
         ledger: response.ledger,
         createdAt: new Date(),
         fee: '0',
       };
+      this.emitEscrowChanged('refunded', {
+        orderId: params.balanceId,
+        transactionHash: refundStatus.transactionHash,
+        balanceId: params.balanceId,
+      });
+      return refundStatus;
     } catch (err) {
       this.handleStellarError(err, 'refundEscrow');
     }
@@ -1056,6 +1101,27 @@ export class StellarService implements OnModuleInit {
     if (!StellarSdk.StrKey.isValidEd25519PublicKey(key)) {
       throw new BadRequestException(`Invalid Stellar public key: ${key}`);
     }
+  }
+
+  private emitEscrowChanged(
+    action: EscrowChangeAction,
+    payload: {
+      orderId: string;
+      transactionHash?: string;
+      balanceId?: string;
+      amount?: string;
+    },
+  ): void {
+    this.eventEmitter.emit(
+      DomainEventNames.ESCROW_CHANGED,
+      new EscrowChangedEvent(
+        action,
+        payload.orderId,
+        payload.transactionHash,
+        payload.balanceId,
+        payload.amount,
+      ),
+    );
   }
 
   /** Validates that an amount is a positive numeric string. */

--- a/harvest-finance/backend/src/stellar/tests/stellar.feebump.spec.ts
+++ b/harvest-finance/backend/src/stellar/tests/stellar.feebump.spec.ts
@@ -1,9 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigModule } from '@nestjs/config';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { CustomLoggerService } from '../../logger/custom-logger.service';
 import * as StellarSdk from 'stellar-sdk';
 import { StellarService } from '../services/stellar.service';
 import { SecretsService } from '../../common/secrets/secrets.service';
 import { FeeBumpScenario } from '../interfaces/stellar.interfaces';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { CustomLoggerService } from '../../logger/custom-logger.service';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -70,6 +74,11 @@ describe('StellarService — Fee-Bump & MEV Testing', () => {
               Promise.resolve(platformKeypair.secret()),
           },
         },
+        {
+          provide: CustomLoggerService,
+          useValue: { log: jest.fn(), error: jest.fn(), warn: jest.fn() },
+        },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
       ],
     }).compile();
 

--- a/harvest-finance/backend/src/stellar/tests/stellar.integration.spec.ts
+++ b/harvest-finance/backend/src/stellar/tests/stellar.integration.spec.ts
@@ -4,6 +4,8 @@ import * as StellarSdk from '@stellar/stellar-sdk';
 import { StellarService } from '../services/stellar.service';
 import { SecretsService } from '../../common/secrets/secrets.service';
 import { BadRequestException } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { CustomLoggerService } from '../../logger/custom-logger.service';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -72,6 +74,11 @@ describe('StellarService — Testnet Integration', () => {
               Promise.resolve(platformKeypair.secret()),
           },
         },
+        {
+          provide: CustomLoggerService,
+          useValue: { log: jest.fn(), error: jest.fn(), warn: jest.fn() },
+        },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
       ],
     }).compile();
 

--- a/harvest-finance/backend/src/stellar/tests/stellar.unit.spec.ts
+++ b/harvest-finance/backend/src/stellar/tests/stellar.unit.spec.ts
@@ -2,6 +2,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { StellarService } from '../services/stellar.service';
 import { SecretsService } from '../../common/secrets/secrets.service';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { CustomLoggerService } from '../../logger/custom-logger.service';
 
 describe('StellarService (unit)', () => {
   let service: StellarService;
@@ -37,6 +39,11 @@ describe('StellarService (unit)', () => {
             },
           },
         },
+        {
+          provide: CustomLoggerService,
+          useValue: { log: jest.fn(), error: jest.fn(), warn: jest.fn() },
+        },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
       ],
     }).compile();
 

--- a/harvest-finance/backend/src/vaults/vaults.service.spec.ts
+++ b/harvest-finance/backend/src/vaults/vaults.service.spec.ts
@@ -12,6 +12,9 @@ import {
 import { NotificationsService } from '../notifications/notifications.service';
 import { CustomLoggerService } from '../logger/custom-logger.service';
 import { VaultGateway } from '../realtime/vault.gateway';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ContractCacheService } from '../common/cache/contract-cache.service';
+import { InputSanitizerService } from '../common/sanitization/input-sanitizer.service';
 
 describe('VaultsService', () => {
   let service: VaultsService;
@@ -62,6 +65,13 @@ describe('VaultsService', () => {
     emitDeposit: jest.fn(),
     emitWithdrawal: jest.fn(),
   };
+  const mockEventEmitter = { emit: jest.fn() };
+  const mockContractCache = {
+    getVaultState: jest.fn((_id: string, fn: () => Promise<Vault>) => fn()),
+  };
+  const mockSanitizer = {
+    validateUUID: jest.fn((id: string) => id),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -80,6 +90,9 @@ describe('VaultsService', () => {
         { provide: NotificationsService, useValue: mockNotificationsService },
         { provide: CustomLoggerService, useValue: mockLogger },
         { provide: VaultGateway, useValue: mockVaultGateway },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
+        { provide: ContractCacheService, useValue: mockContractCache },
+        { provide: InputSanitizerService, useValue: mockSanitizer },
       ],
     }).compile();
 

--- a/harvest-finance/backend/src/vaults/vaults.service.ts
+++ b/harvest-finance/backend/src/vaults/vaults.service.ts
@@ -26,6 +26,12 @@ import { ContractCacheService } from '../common/cache/contract-cache.service';
 import { InputSanitizerService } from '../common/sanitization/input-sanitizer.service';
 import { VaultApproval } from '../database/entities/vault-approval.entity';
 import { User } from '../database/entities/user.entity';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import {
+  DepositCompletedEvent,
+  DomainEventNames,
+  WithdrawalCompletedEvent,
+} from '../domain-events';
 
 const MAX_SAFE_DEPOSIT = 1e30;
 const LARGE_DEPOSIT_THRESHOLD = 10000;
@@ -45,6 +51,7 @@ export class VaultsService {
     private vaultGateway: VaultGateway,
     private contractCache: ContractCacheService,
     private sanitizer: InputSanitizerService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async getVaultById(vaultId: string): Promise<Vault> {
@@ -178,6 +185,18 @@ export class VaultsService {
       userId,
       newBalance: result.vault ? Number(result.vault.totalDeposits) : 0,
     });
+
+    this.eventEmitter.emit(
+      DomainEventNames.DEPOSIT_COMPLETED,
+      new DepositCompletedEvent(
+        confirmedDeposit.id,
+        userId,
+        vaultId,
+        amount,
+        vault.vaultName,
+        result.vault ? Number(result.vault.totalDeposits) : 0,
+      ),
+    );
 
     return {
       vault: result.vault ? this.mapVaultToResponse(result.vault) : null,
@@ -377,6 +396,18 @@ export class VaultsService {
       userId,
       newBalance: result.vault ? Number(result.vault.totalDeposits) : 0,
     });
+
+    this.eventEmitter.emit(
+      DomainEventNames.WITHDRAWAL_COMPLETED,
+      new WithdrawalCompletedEvent(
+        confirmedWithdrawal.id,
+        userId,
+        vaultId,
+        amount,
+        vault.vaultName,
+        result.vault ? Number(result.vault.totalDeposits) : 0,
+      ),
+    );
 
     return {
       withdrawal: confirmedWithdrawal,


### PR DESCRIPTION
## Summary
Adds typed domain events for vault deposits, vault withdrawals, and escrow lifecycle changes using NestJS `EventEmitter2`.

## Purpose / Motivation
Event-driven side effects are easier to test and extend than scattering direct service calls. Downstream features (analytics, notifications, audit logs) can subscribe with `@OnEvent` without modifying core vault or Stellar flows.

## Changes Made
- Introduced `DomainEventsModule` (global) with event name constants and typed payloads:
  - `DepositCompletedEvent` (`vault.deposit.completed`)
  - `WithdrawalCompletedEvent` (`vault.withdrawal.completed`)
  - `EscrowChangedEvent` (`escrow.changed`) with actions `created`, `released`, `refunded`
- `VaultsService` emits deposit/withdrawal events after successful confirmation
- `OrdersService` emits escrow events when orders enter escrow or upfront payment is released
- `StellarService` emits escrow events on create, release, and refund
- Unit test mocks updated for `EventEmitter2` injection

## How to Test
1. Run backend unit tests: `cd harvest-finance/backend && npm test`
2. Deposit to a vault via API; add a temporary `@OnEvent(DomainEventNames.DEPOSIT_COMPLETED)` handler and confirm payload includes `depositId`, `userId`, `vaultId`, and `amount`
3. Withdraw from a vault; confirm `vault.withdrawal.completed` fires with matching withdrawal id
4. Accept an order (escrow created) or call Stellar escrow endpoints; confirm `escrow.changed` events with the expected `action`

## Screenshots (if applicable)
N/A — backend-only change.

## Breaking Changes
- None. Existing WebSocket and notification behavior is unchanged; events are additive.

## Related Issues
Closes code-flexing/Harvest-Finance#382

## Checklist
- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [ ] Documentation updated (if needed)
