### PR TITLE
Improve backend developer setup and startup reliability

### DIFF
--- a/harvest-finance/backend/README.md
+++ b/harvest-finance/backend/README.md
@@ -58,7 +58,20 @@ JWT_REFRESH_EXPIRES_IN=7d
 # Rate Limiting
 THROTTLE_TTL=60000
 THROTTLE_LIMIT=100
+
+# Logging
+LOG_LEVEL=info
+LOG_PRETTY=true
 ```
+
+## Logging Configuration
+
+The backend uses pino through `CustomLoggerService`.
+
+- `LOG_LEVEL` controls the minimum emitted level. Supported values are `trace`, `debug`, `info`, `warn`, `error`, and `fatal`. The default is `info`.
+- `LOG_PRETTY` controls the console transport. Set it to `true` for colorized `pino-pretty` output during local development, or `false` for JSON lines on stdout. When unset, local environments use pretty logs and production uses JSON logs.
+- File transports always write `logs/application.log` for all levels and `logs/error.log` for errors.
+- Sensitive fields are redacted before pino writes them. The current redaction list includes passwords, refresh tokens, access tokens, authorization headers, generic token fields, and generic secret fields on top-level payloads, request headers, body payloads, and user payloads.
 
 ## Authentication Guide
 

--- a/harvest-finance/backend/package.json
+++ b/harvest-finance/backend/package.json
@@ -7,6 +7,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "build": "nest build",
+    "type-check": "tsc --noEmit",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",

--- a/harvest-finance/backend/package.json
+++ b/harvest-finance/backend/package.json
@@ -65,6 +65,7 @@
     "class-validator": "^0.14.3",
     "date-fns": "^4.1.0",
     "ethers": "^6.16.0",
+    "envalid": "^8.0.0",
     "exceljs": "^4.4.0",
     "fast-csv": "^5.0.5",
     "graphql": "^16.14.0",

--- a/harvest-finance/backend/package.json
+++ b/harvest-finance/backend/package.json
@@ -84,6 +84,7 @@
     "zustand": "^5.0.11"
   },
   "devDependencies": {
+    "@faker-js/faker": "^9.9.0",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.18.0",
     "@nestjs/cli": "^11.0.0",

--- a/harvest-finance/backend/src/app.module.ts
+++ b/harvest-finance/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { GraphQLModule } from '@nestjs/graphql';
 import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { validateEnvironment } from './common/config/env.validation';
 import { buildThrottlerOptions } from './common/config/throttler.config';
 import { CommonModule } from './common/common.module';
 import { RequestValidationMiddleware } from './common/middleware/request-validation.middleware';
@@ -82,7 +83,7 @@ import { DomainEventsModule } from './domain-events';
 
 @Module({
   imports: [
-    ConfigModule.forRoot({ isGlobal: true }),
+    ConfigModule.forRoot({ isGlobal: true, validate: validateEnvironment }),
     DomainEventsModule,
     ThrottlerModule.forRootAsync({
       imports: [ConfigModule],

--- a/harvest-finance/backend/src/common/config/env.validation.ts
+++ b/harvest-finance/backend/src/common/config/env.validation.ts
@@ -1,0 +1,67 @@
+import {
+  bool,
+  cleanEnv,
+  num,
+  port,
+  str,
+  testOnly,
+  url,
+} from 'envalid';
+
+const logLevels = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'] as const;
+const nodeEnvironments = [
+  'development',
+  'production',
+  'test',
+  'staging',
+] as const;
+
+export function validateEnvironment(
+  config: Record<string, unknown>,
+): Record<string, unknown> {
+  return cleanEnv(
+    config,
+    {
+      NODE_ENV: str({
+        choices: nodeEnvironments,
+        default: 'development',
+        devDefault: testOnly('test'),
+      }),
+      PORT: port({ default: 5000 }),
+      DB_HOST: str(),
+      DB_PORT: port(),
+      DB_USER: str(),
+      DB_PASSWORD: str(),
+      DB_NAME: str(),
+      JWT_SECRET: str(),
+      JWT_EXPIRES_IN: str({ default: '1h' }),
+      JWT_REFRESH_SECRET: str(),
+      JWT_REFRESH_EXPIRES_IN: str({ default: '7d' }),
+      REDIS_URL: url({ default: 'redis://localhost:6379' }),
+      THROTTLE_SHORT_TTL: num({ default: 1000 }),
+      THROTTLE_SHORT_LIMIT: num({ default: 5 }),
+      THROTTLE_MEDIUM_TTL: num({ default: 10_000 }),
+      THROTTLE_MEDIUM_LIMIT: num({ default: 30 }),
+      THROTTLE_TTL: num({ default: 60_000 }),
+      THROTTLE_LIMIT: num({ default: 100 }),
+      LOG_LEVEL: str({ choices: logLevels, default: 'info' }),
+      LOG_PRETTY: bool({ default: false }),
+    },
+    {
+      reporter: ({ errors }) => {
+        const messages = Object.entries(errors);
+
+        if (messages.length === 0) return;
+
+        throw new Error(
+          [
+            'Invalid environment configuration:',
+            ...messages.map(
+              ([name, error]) => `- ${name}: ${error?.message ?? 'is invalid'}`,
+            ),
+          ].join('\n'),
+        );
+      },
+    },
+  );
+}

--- a/harvest-finance/backend/src/common/config/env.validation.ts
+++ b/harvest-finance/backend/src/common/config/env.validation.ts
@@ -45,7 +45,7 @@ export function validateEnvironment(
       THROTTLE_TTL: num({ default: 60_000 }),
       THROTTLE_LIMIT: num({ default: 100 }),
       LOG_LEVEL: str({ choices: logLevels, default: 'info' }),
-      LOG_PRETTY: bool({ default: false }),
+      LOG_PRETTY: bool({ default: false, devDefault: true }),
     },
     {
       reporter: ({ errors }) => {

--- a/harvest-finance/backend/src/database/data-source.ts
+++ b/harvest-finance/backend/src/database/data-source.ts
@@ -5,7 +5,10 @@ import { Order } from './entities/order.entity';
 import { Transaction } from './entities/transaction.entity';
 import { Verification } from './entities/verification.entity';
 import { CreditScore } from './entities/credit-score.entity';
+import { Deposit } from './entities/deposit.entity';
 import { SorobanEvent } from './entities/soroban-event.entity';
+import { Vault } from './entities/vault.entity';
+import { VaultDeposit } from './entities/vault-deposit.entity';
 import { CreateInitialSchema1700000000000 } from './migrations/1700000000000-CreateInitialSchema';
 import { CreateSorobanEvents1700000000011 } from './migrations/1700000000011-CreateSorobanEvents';
 import { AddSorobanEventQueryIndexes1700000000013 } from './migrations/1700000000013-AddSorobanEventQueryIndexes';
@@ -29,7 +32,17 @@ const options: DataSourceOptions = {
   username: process.env.DB_USER || 'postgres',
   password: process.env.DB_PASSWORD || 'password',
   database: process.env.DB_NAME || 'harvest_finance',
-  entities: [User, Order, Transaction, Verification, CreditScore, SorobanEvent],
+  entities: [
+    User,
+    Order,
+    Transaction,
+    Verification,
+    CreditScore,
+    Deposit,
+    SorobanEvent,
+    Vault,
+    VaultDeposit,
+  ],
   migrations: [
     CreateInitialSchema1700000000000,
     CreateSorobanEvents1700000000011,

--- a/harvest-finance/backend/src/database/seed/seed.data.ts
+++ b/harvest-finance/backend/src/database/seed/seed.data.ts
@@ -1,435 +1,85 @@
-import { DataSource } from 'typeorm';
+import { faker } from '@faker-js/faker';
 import * as bcrypt from 'bcrypt';
+import { DataSource, Repository } from 'typeorm';
+import { Deposit, DepositStatus } from '../entities/deposit.entity';
 import { User, UserRole } from '../entities/user.entity';
-import { Order, OrderStatus } from '../entities/order.entity';
 import {
-  Transaction,
-  TransactionStatus,
-  TransactionType,
-} from '../entities/transaction.entity';
-import {
-  Verification,
-  VerificationStatus,
-} from '../entities/verification.entity';
-import { CreditScore } from '../entities/credit-score.entity';
-import { CropCycle } from '../entities/crop-cycle.entity';
-import { FarmVault } from '../entities/farm-vault.entity';
+  Vault,
+  VaultStatus,
+  VaultType,
+} from '../entities/vault.entity';
+import { VaultDeposit } from '../entities/vault-deposit.entity';
 
-/**
- * Seed Data Configuration
- *
- * This file contains sample data for testing and development purposes.
- * Run with: npm run seed
- */
-export interface SeedConfig {
-  users: Partial<User>[];
-  orders: Partial<Order>[];
-  transactions: Partial<Transaction>[];
-  verifications: Partial<Verification>[];
-  creditScores: Partial<CreditScore>[];
+const DEFAULT_PASSWORD = 'password123';
+const SEED_USER_COUNT = 18;
+const SEED_VAULT_COUNT = 10;
+const SEED_DEPOSIT_COUNT = 48;
+
+interface SeedResult {
+  users: User[];
+  vaults: Vault[];
+  deposits: Deposit[];
+  vaultDeposits: VaultDeposit[];
 }
 
-/**
- * Generate seed data for the database
- *
- * This function creates sample data for all entities:
- * - 3 Farmers
- * - 2 Buyers
- * - 1 Inspector
- * - 1 Admin
- * - Multiple orders in various statuses
- * - Transactions and verifications
- * - Credit scores for farmers
- */
+const cropThemes = [
+  'Cassava',
+  'Maize',
+  'Rice',
+  'Soybean',
+  'Cocoa',
+  'Tomato',
+  'Groundnut',
+  'Sorghum',
+];
+
+const vaultTypeLabels: Record<VaultType, string> = {
+  [VaultType.CROP_PRODUCTION]: 'Production',
+  [VaultType.EQUIPMENT_FINANCING]: 'Equipment',
+  [VaultType.LAND_ACQUISITION]: 'Land',
+  [VaultType.INSURANCE_FUND]: 'Insurance',
+  [VaultType.EMERGENCY_FUND]: 'Emergency',
+};
+
 export async function generateSeedData(
   dataSource: DataSource,
-): Promise<SeedConfig> {
+): Promise<SeedResult> {
+  faker.seed(20260602);
+
   const userRepository = dataSource.getRepository(User);
-  const orderRepository = dataSource.getRepository(Order);
-  const transactionRepository = dataSource.getRepository(Transaction);
-  const verificationRepository = dataSource.getRepository(Verification);
-  const creditScoreRepository = dataSource.getRepository(CreditScore);
-  const cropCycleRepository = dataSource.getRepository(CropCycle);
+  const vaultRepository = dataSource.getRepository(Vault);
+  const depositRepository = dataSource.getRepository(Deposit);
+  const vaultDepositRepository = dataSource.getRepository(VaultDeposit);
+  const hashedPassword = await bcrypt.hash(DEFAULT_PASSWORD, 10);
 
-  // Hash password for all users
-  const hashedPassword = await bcrypt.hash('password123', 10);
+  const users = await userRepository.save(createUsers(hashedPassword));
+  const farmers = users.filter((user) => user.role === UserRole.FARMER);
+  const vaults = await vaultRepository.save(createVaults(farmers));
+  const deposits = await depositRepository.save(createDeposits(users, vaults));
+  await updateVaultTotals(vaultRepository, vaults, deposits);
+  const vaultDeposits = await vaultDepositRepository.save(
+    createVaultDepositBalances(users, vaults, deposits),
+  );
 
-  // Create Users
-  const farmer1 = await userRepository.save({
-    email: 'john.farmer@harvest.finance',
-    password: hashedPassword,
-    role: UserRole.FARMER,
-    firstName: 'John',
-    lastName: 'Smith',
-    stellarAddress: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890',
-    phone: '+2348012345678',
-    address: '123 Farm Road, Lagos, Nigeria',
-    isActive: true,
-  });
-
-  const farmer2 = await userRepository.save({
-    email: 'grace.farmer@harvest.finance',
-    password: hashedPassword,
-    role: UserRole.FARMER,
-    firstName: 'Grace',
-    lastName: 'Adamu',
-    stellarAddress: 'GDEF2345678901BCDEFGHIJKLMNOPQRSTUVWXYZ1234567890',
-    phone: '+2348012345679',
-    address: '456 Agriculture Ave, Abuja, Nigeria',
-    isActive: true,
-  });
-
-  const farmer3 = await userRepository.save({
-    email: 'michael.farmer@harvest.finance',
-    password: hashedPassword,
-    role: UserRole.FARMER,
-    firstName: 'Michael',
-    lastName: 'Okafor',
-    stellarAddress: 'GHIJ3456789012CDEFGHIJKLMNOPQRSTUVWXYZ1234567890',
-    phone: '+2348012345680',
-    address: '789 Harvest Lane, Kano, Nigeria',
-    isActive: true,
-  });
-
-  const buyer1 = await userRepository.save({
-    email: 'emma.buyer@harvest.finance',
-    password: hashedPassword,
-    role: UserRole.BUYER,
-    firstName: 'Emma',
-    lastName: 'Johnson',
-    stellarAddress: 'GKLN4567890123DEFGHIJKLMNOPQRSTUVWXYZ1234567890',
-    phone: '+2348012345681',
-    address: 'Market Street, Lagos, Nigeria',
-    isActive: true,
-  });
-
-  const buyer2 = await userRepository.save({
-    email: 'david.buyer@harvest.finance',
-    password: hashedPassword,
-    role: UserRole.BUYER,
-    firstName: 'David',
-    lastName: 'Chukwu',
-    stellarAddress: 'GMNO5678901234EFGHIJKLMNOPQRSTUVWXYZ1234567890',
-    phone: '+2348012345682',
-    address: 'Commerce Road, Port Harcourt, Nigeria',
-    isActive: true,
-  });
-
-  const inspector = await userRepository.save({
-    email: 'inspector@harvest.finance',
-    password: hashedPassword,
-    role: UserRole.INSPECTOR,
-    firstName: 'Sarah',
-    lastName: 'Williams',
-    stellarAddress: 'GPQR6789012345FGHIJKLMNOPQRSTUVWXYZ1234567890',
-    phone: '+2348012345683',
-    address: 'Quality Control Office, Lagos, Nigeria',
-    isActive: true,
-  });
-
-  const admin = await userRepository.save({
-    email: 'admin@harvest.finance',
-    password: hashedPassword,
-    role: UserRole.ADMIN,
-    firstName: 'Admin',
-    lastName: 'User',
-    stellarAddress: 'GSTU7890123456GHIJKLMNOPQRSTUVWXYZ1234567890',
-    phone: '+2348012345684',
-    address: 'Headquarters, Lagos, Nigeria',
-    isActive: true,
-  });
-
-  // Create Orders
-  const order1 = await orderRepository.save({
-    farmerId: farmer1.id,
-    buyerId: buyer1.id,
-    cropType: 'Maize',
-    quantity: 1000,
-    quantityUnit: 'kg',
-    price: 250000,
-    status: OrderStatus.COMPLETED,
-    description: 'High quality yellow maize, suitable for animal feed',
-    deliveryAddress: 'Warehouse A, Lagos Port',
-    expectedDeliveryDate: new Date('2024-03-15'),
-    escrowTxHash: 'abc123def456',
-  });
-
-  const order2 = await orderRepository.save({
-    farmerId: farmer2.id,
-    buyerId: buyer1.id,
-    cropType: 'Rice',
-    quantity: 500,
-    quantityUnit: 'kg',
-    price: 300000,
-    status: OrderStatus.IN_ESCROW,
-    description: 'Premium long grain rice, well polished',
-    deliveryAddress: 'Warehouse B, Apapa, Lagos',
-    expectedDeliveryDate: new Date('2024-04-01'),
-    escrowTxHash: 'def456ghi789',
-  });
-
-  const order3 = await orderRepository.save({
-    farmerId: farmer1.id,
-    buyerId: buyer2.id,
-    cropType: 'Cassava',
-    quantity: 2000,
-    quantityUnit: 'kg',
-    price: 100000,
-    status: OrderStatus.PENDING,
-    description: 'Fresh cassava tubers, high starch content',
-    deliveryAddress: 'Warehouse C, Port Harcourt',
-    expectedDeliveryDate: new Date('2024-04-15'),
-  });
-
-  const order4 = await orderRepository.save({
-    farmerId: farmer3.id,
-    buyerId: buyer2.id,
-    cropType: 'Soybeans',
-    quantity: 800,
-    quantityUnit: 'kg',
-    price: 280000,
-    status: OrderStatus.ACCEPTED,
-    description: 'Organic soybeans, non-GMO certified',
-    deliveryAddress: 'Warehouse D, Kano',
-    expectedDeliveryDate: new Date('2024-04-20'),
-  });
-
-  const order5 = await orderRepository.save({
-    farmerId: farmer2.id,
-    buyerId: buyer1.id,
-    cropType: 'Tomatoes',
-    quantity: 300,
-    quantityUnit: 'kg',
-    price: 90000,
-    status: OrderStatus.CANCELLED,
-    description: 'Fresh tomatoes, red and ripe',
-    deliveryAddress: 'Warehouse A, Lagos',
-    expectedDeliveryDate: new Date('2024-02-28'),
-  });
-
-  const order6 = await orderRepository.save({
-    farmerId: farmer3.id,
-    buyerId: buyer1.id,
-    cropType: 'Groundnuts',
-    quantity: 600,
-    quantityUnit: 'kg',
-    price: 180000,
-    status: OrderStatus.EXPIRED,
-    description: 'Quality groundnuts, ready for processing',
-    deliveryAddress: 'Warehouse B, Abuja',
-    expectedDeliveryDate: new Date('2024-01-15'),
-  });
-
-  // Create Transactions
-  const transaction1 = await transactionRepository.save({
-    orderId: order1.id,
-    stellarTxHash: 'tx1234567890abcdef',
-    amount: 250000,
-    assetCode: 'USDC',
-    assetIssuer: 'GA5ZSEJYJ37T3KNRG4B3GWGZ3Z5J6B7Z8Z9Z0Z1Z2Z3Z4Z5Z6Z7Z8Z9Z0',
-    status: TransactionStatus.CONFIRMED,
-    type: TransactionType.ESCROW_DEPOSIT,
-    sourceAccount: buyer1.stellarAddress,
-    destinationAccount: farmer1.stellarAddress,
-    stellarMemo: 'Order-001',
-    confirmedAt: new Date('2024-02-10'),
-    memo: 'Payment for maize order #1',
-  });
-
-  const transaction2 = await transactionRepository.save({
-    orderId: order1.id,
-    stellarTxHash: 'tx2345678901bcdefg',
-    amount: 250000,
-    assetCode: 'USDC',
-    assetIssuer: 'GA5ZSEJYJ37T3KNRG4B3GWGZ3Z5J6B7Z8Z9Z0Z1Z2Z3Z4Z5Z6Z7Z8Z9Z0',
-    status: TransactionStatus.CONFIRMED,
-    type: TransactionType.ESCROW_RELEASE,
-    sourceAccount: 'escrow_account',
-    destinationAccount: farmer1.stellarAddress,
-    stellarMemo: 'Order-001-release',
-    confirmedAt: new Date('2024-03-16'),
-    memo: 'Release payment for completed order #1',
-  });
-
-  const transaction3 = await transactionRepository.save({
-    orderId: order2.id,
-    stellarTxHash: 'tx3456789012cdefgh',
-    amount: 300000,
-    assetCode: 'USDC',
-    assetIssuer: 'GA5ZSEJYJ37T3KNRG4B3GWGZ3Z5J6B7Z8Z9Z0Z1Z2Z3Z4Z5Z6Z7Z8Z9Z0',
-    status: TransactionStatus.PENDING,
-    type: TransactionType.ESCROW_DEPOSIT,
-    sourceAccount: buyer1.stellarAddress,
-    destinationAccount: 'escrow_account',
-    stellarMemo: 'Order-002',
-    memo: 'Escrow deposit for rice order #2',
-  });
-
-  const transaction4 = await transactionRepository.save({
-    orderId: order5.id,
-    stellarTxHash: 'tx4567890123defghi',
-    amount: 90000,
-    assetCode: 'USDC',
-    assetIssuer: 'GA5ZSEJYJ37T3KNRG4B3GWGZ3Z5J6B7Z8Z9Z0Z1Z2Z3Z4Z5Z6Z7Z8Z9Z0',
-    status: TransactionStatus.CANCELLED,
-    type: TransactionType.ESCROW_REFUND,
-    sourceAccount: 'escrow_account',
-    destinationAccount: buyer1.stellarAddress,
-    stellarMemo: 'Order-005-refund',
-    memo: 'Refund for cancelled tomatoes order #5',
-  });
-
-  // Create Verifications
-  const verification1 = await verificationRepository.save({
-    orderId: order1.id,
-    inspectorId: inspector.id,
-    proofHash: 'ipfs://QmProof1234567890',
-    status: VerificationStatus.APPROVED,
-    notes: 'Quality verified. Maize meets all standards.',
-    inspectionDate: new Date('2024-03-14'),
-    cropQuality: 'A+',
-    quantityVerified: 1000,
-    verificationDocuments: ['ipfs://QmDoc1', 'ipfs://QmDoc2'],
-    approvedAt: new Date('2024-03-14'),
-  });
-
-  const verification2 = await verificationRepository.save({
-    orderId: order2.id,
-    inspectorId: inspector.id,
-    proofHash: 'ipfs://QmProof2345678901',
-    status: VerificationStatus.PENDING,
-    notes: 'Inspection scheduled for tomorrow',
-    inspectionDate: new Date('2024-03-25'),
-    cropQuality: null,
-    quantityVerified: null,
-    verificationDocuments: null,
-  });
-
-  const verification3 = await verificationRepository.save({
-    orderId: order4.id,
-    inspectorId: inspector.id,
-    proofHash: 'ipfs://QmProof3456789012',
-    status: VerificationStatus.APPROVED,
-    notes: 'Organic certification verified. All quality checks passed.',
-    inspectionDate: new Date('2024-03-18'),
-    cropQuality: 'A',
-    quantityVerified: 800,
-    verificationDocuments: ['ipfs://QmDoc3', 'ipfs://QmDoc4'],
-    approvedAt: new Date('2024-03-18'),
-  });
-
-  const verification4 = await verificationRepository.save({
-    orderId: order5.id,
-    inspectorId: inspector.id,
-    proofHash: 'ipfs://QmProof4567890123',
-    status: VerificationStatus.REJECTED,
-    notes: 'Tomatoes were overripe and not suitable for delivery.',
-    inspectionDate: new Date('2024-02-25'),
-    cropQuality: 'C',
-    quantityVerified: 250,
-    verificationDocuments: ['ipfs://QmDoc5'],
-    rejectedAt: new Date('2024-02-25'),
-  });
-
-  // Create Credit Scores
-  const creditScore1 = await creditScoreRepository.save({
-    farmerId: farmer1.id,
-    score: 850,
-    totalTransactions: 15,
-    successfulTransactions: 14,
-    failedTransactions: 1,
-    totalVolume: 2500000,
-    averageRating: 4.5,
-    totalRatings: 12,
-    history: [
-      {
-        date: new Date('2024-01-01'),
-        score: 780,
-        reason: 'Initial score',
-      },
-      {
-        date: new Date('2024-02-01'),
-        score: 800,
-        reason: 'Successful order completed',
-        orderId: order1.id,
-      },
-      {
-        date: new Date('2024-03-15'),
-        score: 850,
-        reason: 'Excellent delivery and quality',
-        orderId: order1.id,
-      },
-    ],
-    lastUpdated: new Date('2024-03-15'),
-    lastOrderId: order1.id,
-  });
-
-  const creditScore2 = await creditScoreRepository.save({
-    farmerId: farmer2.id,
-    score: 720,
-    totalTransactions: 8,
-    successfulTransactions: 7,
-    failedTransactions: 1,
-    totalVolume: 1200000,
-    averageRating: 4.0,
-    totalRatings: 6,
-    history: [
-      {
-        date: new Date('2024-01-15'),
-        score: 700,
-        reason: 'Initial score',
-      },
-      {
-        date: new Date('2024-02-20'),
-        score: 720,
-        reason: 'Successful transaction',
-        orderId: order2.id,
-      },
-    ],
-    lastUpdated: new Date('2024-02-20'),
-    lastOrderId: order2.id,
-  });
-
-  const creditScore3 = await creditScoreRepository.save({
-    farmerId: farmer3.id,
-    score: 650,
-    totalTransactions: 3,
-    successfulTransactions: 3,
-    failedTransactions: 0,
-    totalVolume: 450000,
-    averageRating: 3.8,
-    totalRatings: 2,
-    history: [
-      {
-        date: new Date('2024-02-01'),
-        score: 650,
-        reason: 'Initial score',
-      },
-    ],
-    lastUpdated: new Date('2024-02-01'),
-    lastOrderId: order4.id,
-  });
-
-  console.log('✅ Seed data created successfully!');
-  console.log(`   - Users: 7 (3 farmers, 2 buyers, 1 inspector, 1 admin)`);
-  console.log(`   - Orders: 6 (various statuses)`);
-  console.log(`   - Transactions: 4`);
-  console.log(`   - Verifications: 4`);
-  console.log(`   - Credit Scores: 3`);
+  console.log('Seed data created successfully.');
+  console.log(`   - Users: ${users.length}`);
+  console.log(`   - Vaults: ${vaults.length}`);
+  console.log(`   - Deposits: ${deposits.length}`);
+  console.log(`   - Vault balances: ${vaultDeposits.length}`);
+  console.log(`   - Default password: ${DEFAULT_PASSWORD}`);
 
   return {
-    users: [farmer1, farmer2, farmer3, buyer1, buyer2, inspector, admin],
-    orders: [order1, order2, order3, order4, order5, order6],
-    transactions: [transaction1, transaction2, transaction3, transaction4],
-    verifications: [verification1, verification2, verification3, verification4],
-    creditScores: [creditScore1, creditScore2, creditScore3],
+    users,
+    vaults,
+    deposits,
+    vaultDeposits,
   };
 }
 
-/**
- * Clear all seed data from the database
- */
 export async function clearSeedData(dataSource: DataSource): Promise<void> {
+  await dataSource.query('DELETE FROM vault_deposits');
+  await dataSource.query('DELETE FROM deposits');
+  await dataSource.query('DELETE FROM vaults');
   await dataSource.query('DELETE FROM credit_scores');
   await dataSource.query('DELETE FROM verifications');
   await dataSource.query('DELETE FROM transactions');
@@ -437,5 +87,185 @@ export async function clearSeedData(dataSource: DataSource): Promise<void> {
   await dataSource.query('DELETE FROM farm_vaults');
   await dataSource.query('DELETE FROM crop_cycles');
   await dataSource.query('DELETE FROM users');
-  console.log('✅ Seed data cleared!');
+  console.log('Seed data cleared.');
+}
+
+function createUsers(hashedPassword: string): Partial<User>[] {
+  const roles = [
+    ...Array<UserRole>(10).fill(UserRole.FARMER),
+    ...Array<UserRole>(5).fill(UserRole.BUYER),
+    ...Array<UserRole>(2).fill(UserRole.INSPECTOR),
+    UserRole.ADMIN,
+  ];
+
+  return faker.helpers.shuffle(roles).slice(0, SEED_USER_COUNT).map((role) => {
+    const firstName = faker.person.firstName();
+    const lastName = faker.person.lastName();
+
+    return {
+      email: faker.internet.email({ firstName, lastName }).toLowerCase(),
+      password: hashedPassword,
+      role,
+      firstName,
+      lastName,
+      stellarAddress: createStellarAddress(),
+      phone: faker.phone.number(),
+      address: `${faker.location.streetAddress()}, ${faker.location.city()}, ${faker.location.country()}`,
+      profileImageUrl: faker.image.avatar(),
+      isActive: faker.datatype.boolean({ probability: 0.94 }),
+      lastLogin: faker.date.recent({ days: 30 }),
+    };
+  });
+}
+
+function createVaults(farmers: User[]): Partial<Vault>[] {
+  return Array.from({ length: SEED_VAULT_COUNT }, () => {
+    const owner = faker.helpers.arrayElement(farmers);
+    const type = faker.helpers.enumValue(VaultType);
+    const crop = faker.helpers.arrayElement(cropThemes);
+    const maxCapacity = faker.number.float({
+      min: 25_000,
+      max: 350_000,
+      fractionDigits: 2,
+    });
+    const requiresMultiSignature = faker.datatype.boolean({
+      probability: 0.25,
+    });
+
+    return {
+      ownerId: owner.id,
+      type,
+      status: VaultStatus.ACTIVE,
+      vaultName: `${crop} ${vaultTypeLabels[type]} Vault`,
+      description: faker.lorem.sentence({ min: 10, max: 18 }),
+      symbol: `HV${crop.slice(0, 3).toUpperCase()}`,
+      assetPair: faker.helpers.arrayElement(['XLM/USDC', 'XLM/HVF', 'USDC/HVF']),
+      totalDeposits: 0,
+      maxCapacity,
+      interestRate: faker.number.float({
+        min: 4.5,
+        max: 18,
+        fractionDigits: 2,
+      }),
+      maturityDate: faker.date.future({ years: 3 }),
+      lockPeriodEnd: faker.date.future({ years: 1 }),
+      isPublic: faker.datatype.boolean({ probability: 0.9 }),
+      requiresMultiSignature,
+      approvalThreshold: requiresMultiSignature
+        ? faker.number.int({ min: 2, max: 3 })
+        : 1,
+      currentApprovals: requiresMultiSignature
+        ? faker.number.int({ min: 0, max: 2 })
+        : 0,
+    };
+  });
+}
+
+function createDeposits(users: User[], vaults: Vault[]): Partial<Deposit>[] {
+  return Array.from({ length: SEED_DEPOSIT_COUNT }, () => {
+    const status = faker.helpers.weightedArrayElement([
+      { weight: 8, value: DepositStatus.CONFIRMED },
+      { weight: 2, value: DepositStatus.PENDING },
+      { weight: 1, value: DepositStatus.REFUNDED },
+      { weight: 1, value: DepositStatus.FAILED },
+    ]);
+    const createdAt = faker.date.recent({ days: 120 });
+    const confirmedAt =
+      status === DepositStatus.CONFIRMED
+        ? faker.date.between({ from: createdAt, to: new Date() })
+        : null;
+
+    return {
+      userId: faker.helpers.arrayElement(users).id,
+      vaultId: faker.helpers.arrayElement(vaults).id,
+      status,
+      amount: faker.number.float({
+        min: 100,
+        max: 12_500,
+        fractionDigits: 2,
+      }),
+      transactionHash: status === DepositStatus.FAILED ? null : createTxHash(),
+      stellarTransactionId:
+        status === DepositStatus.FAILED ? null : faker.string.alphanumeric(64),
+      confirmedAt,
+      notes: faker.helpers.maybe(() => faker.finance.transactionDescription(), {
+        probability: 0.35,
+      }),
+      idempotencyKey: faker.string.uuid(),
+      createdAt,
+      updatedAt: confirmedAt ?? createdAt,
+    };
+  });
+}
+
+async function updateVaultTotals(
+  vaultRepository: Repository<Vault>,
+  vaults: Vault[],
+  deposits: Deposit[],
+): Promise<void> {
+  const totalsByVaultId = deposits.reduce<Record<string, number>>(
+    (totals, deposit) => {
+      if (deposit.status !== DepositStatus.CONFIRMED) return totals;
+      totals[deposit.vaultId] =
+        (totals[deposit.vaultId] ?? 0) + Number(deposit.amount);
+      return totals;
+    },
+    {},
+  );
+
+  await Promise.all(
+    vaults.map((vault) => {
+      const totalDeposits = Number((totalsByVaultId[vault.id] ?? 0).toFixed(2));
+      const status =
+        totalDeposits >= Number(vault.maxCapacity)
+          ? VaultStatus.FULL_CAPACITY
+          : VaultStatus.ACTIVE;
+
+      return vaultRepository.update(vault.id, { totalDeposits, status });
+    }),
+  );
+}
+
+function createVaultDepositBalances(
+  users: User[],
+  vaults: Vault[],
+  deposits: Deposit[],
+): Partial<VaultDeposit>[] {
+  const balances = deposits.reduce<Record<string, Partial<VaultDeposit>>>(
+    (accumulator, deposit) => {
+      if (deposit.status !== DepositStatus.CONFIRMED) return accumulator;
+
+      const key = `${deposit.userId}:${deposit.vaultId}`;
+      const user = users.find((candidate) => candidate.id === deposit.userId);
+      const vault = vaults.find((candidate) => candidate.id === deposit.vaultId);
+      if (!user || !vault) return accumulator;
+
+      accumulator[key] = {
+        user,
+        vault,
+        balance:
+          Number(accumulator[key]?.balance ?? 0) + Number(deposit.amount),
+      };
+      return accumulator;
+    },
+    {},
+  );
+
+  return Object.values(balances).map((balance) => ({
+    ...balance,
+    balance: Number(Number(balance.balance).toFixed(2)),
+  }));
+}
+
+function createStellarAddress(): string {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'.split('');
+  const publicKey = Array.from({ length: 55 }, () =>
+    faker.helpers.arrayElement(alphabet),
+  ).join('');
+
+  return `G${publicKey}`;
+}
+
+function createTxHash(): string {
+  return faker.string.hexadecimal({ length: 64, prefix: '0x' });
 }

--- a/harvest-finance/backend/src/database/seed/seed.service.ts
+++ b/harvest-finance/backend/src/database/seed/seed.service.ts
@@ -29,7 +29,7 @@ export class SeedService implements OnModuleInit {
   /**
    * Seed the database with test data
    *
-   * Creates sample users, orders, transactions, verifications, and credit scores
+   * Creates realistic users, vaults, deposits, and vault deposit balances.
    */
   async seed(): Promise<void> {
     this.logger.log('Starting database seeding...');

--- a/harvest-finance/backend/src/logger/custom-logger.service.ts
+++ b/harvest-finance/backend/src/logger/custom-logger.service.ts
@@ -117,10 +117,15 @@ function createPinoLogger(config?: ConfigService): PinoLogger {
   const level =
     config?.get<string>('LOG_LEVEL') ?? process.env.LOG_LEVEL ?? 'info';
   const isProduction = (process.env.NODE_ENV ?? 'development') === 'production';
+  const prettyLogs =
+    config?.get<boolean>('LOG_PRETTY') ??
+    ['true', '1', 'yes'].includes(
+      (process.env.LOG_PRETTY ?? (!isProduction).toString()).toLowerCase(),
+    );
   const logDirectory = path.join(process.cwd(), 'logs');
 
   const targets: TransportTargetOptions[] = [
-    isProduction
+    !prettyLogs
       ? {
           target: 'pino/file',
           options: { destination: 1 },
@@ -150,5 +155,36 @@ function createPinoLogger(config?: ConfigService): PinoLogger {
   ];
 
   const transport = pino.transport({ targets }) as DestinationStream;
-  return pino({ level, base: { pid: process.pid } }, transport);
+  return pino(
+    {
+      level,
+      base: { pid: process.pid },
+      redact: {
+        paths: [
+          'password',
+          'refreshToken',
+          'refresh_token',
+          'access_token',
+          'authorization',
+          'headers.authorization',
+          'req.headers.authorization',
+          'token',
+          'secret',
+          'body.password',
+          'body.refreshToken',
+          'body.refresh_token',
+          'body.access_token',
+          'body.token',
+          'body.secret',
+          'user.password',
+          'user.refreshToken',
+          'user.refresh_token',
+          'user.token',
+          'user.secret',
+        ],
+        censor: '[REDACTED]',
+      },
+    },
+    transport,
+  );
 }


### PR DESCRIPTION
- Add Faker-backed backend seed data for realistic users, vaults, deposits, and vault balances.
- Add backend `npm run type-check` script for standalone `tsc --noEmit`.
- Validate required environment variables at startup with clear failure messages.
- Document pino logging options for log level, pretty output, transports, and redaction.


Closes #419 
Closes #420 
Closes #421 
Closes #422 