### PR TITLE
feat: observability metrics, batch deposits, and async withdrawal confirmation events

### DIFF
--- a/harvest-finance/backend/package.json
+++ b/harvest-finance/backend/package.json
@@ -74,6 +74,7 @@
     "pdfkit": "^0.18.0",
     "pg": "^8.18.0",
     "pino": "^9.14.0",
+    "prom-client": "^15.1.3",
     "react-hook-form": "^7.71.1",
     "recharts": "^3.7.0",
     "redis": "^5.10.0",

--- a/harvest-finance/backend/src/app.module.ts
+++ b/harvest-finance/backend/src/app.module.ts
@@ -38,6 +38,7 @@ import { AdminModule } from './admin/admin.module';
 import { InsuranceModule } from './insurance/insurance.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { RewardsModule } from './rewards/rewards.module';
+import { ObservabilityModule } from './observability/observability.module';
 import {
   Achievement,
   CreditScore,
@@ -85,6 +86,7 @@ import { DomainEventsModule } from './domain-events';
   imports: [
     ConfigModule.forRoot({ isGlobal: true, validate: validateEnvironment }),
     DomainEventsModule,
+    ObservabilityModule,
     ThrottlerModule.forRootAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/harvest-finance/backend/src/domain-events/domain-event-names.ts
+++ b/harvest-finance/backend/src/domain-events/domain-event-names.ts
@@ -1,6 +1,7 @@
 export const DomainEventNames = {
   DEPOSIT_COMPLETED: 'vault.deposit.completed',
   WITHDRAWAL_COMPLETED: 'vault.withdrawal.completed',
+  WITHDRAWAL_CONFIRMED: 'vault.withdrawal.confirmed',
   ESCROW_CHANGED: 'escrow.changed',
 } as const;
 

--- a/harvest-finance/backend/src/domain-events/events/withdrawal-confirmed.event.ts
+++ b/harvest-finance/backend/src/domain-events/events/withdrawal-confirmed.event.ts
@@ -1,0 +1,14 @@
+export class WithdrawalConfirmedEvent {
+  constructor(
+    public readonly withdrawalId: string,
+    public readonly userId: string,
+    public readonly vaultId: string,
+    public readonly amount: number,
+    public readonly vaultName: string,
+    public readonly newBalance: number,
+    public readonly transactionHash: string | null,
+    public readonly confirmedAt: Date,
+    public readonly occurredAt: Date = new Date(),
+  ) {}
+}
+

--- a/harvest-finance/backend/src/domain-events/index.ts
+++ b/harvest-finance/backend/src/domain-events/index.ts
@@ -1,5 +1,6 @@
 export { DomainEventNames } from './domain-event-names';
 export { DepositCompletedEvent } from './events/deposit-completed.event';
+export { WithdrawalConfirmedEvent } from './events/withdrawal-confirmed.event';
 export { WithdrawalCompletedEvent } from './events/withdrawal-completed.event';
 export { EscrowChangedEvent } from './events/escrow-changed.event';
 export type { EscrowChangeAction } from './events/escrow-changed.event';

--- a/harvest-finance/backend/src/observability/metrics/http-metrics.interceptor.ts
+++ b/harvest-finance/backend/src/observability/metrics/http-metrics.interceptor.ts
@@ -1,0 +1,60 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+import { MetricsService } from './metrics.service';
+
+@Injectable()
+export class HttpMetricsInterceptor implements NestInterceptor {
+  constructor(private readonly metrics: MetricsService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    if (context.getType() !== 'http') {
+      return next.handle();
+    }
+
+    const req = context.switchToHttp().getRequest();
+    const res = context.switchToHttp().getResponse();
+
+    // Avoid scraping loops and unnecessary cardinality.
+    const rawPath: string | undefined =
+      req?.route?.path ?? req?.path ?? req?.url ?? req?.originalUrl;
+    if (rawPath === '/metrics') {
+      return next.handle();
+    }
+
+    const start = process.hrtime.bigint();
+
+    return next.handle().pipe(
+      finalize(() => {
+        const durationSeconds = Number(process.hrtime.bigint() - start) / 1e9;
+        const method = String(req?.method ?? 'UNKNOWN');
+        const statusCode = String(res?.statusCode ?? 0);
+        const route = this.buildRouteLabel(req, rawPath);
+
+        this.metrics.httpRequestsTotal
+          .labels(method, route, statusCode)
+          .inc(1);
+
+        this.metrics.httpRequestDurationSeconds
+          .labels(method, route, statusCode)
+          .observe(durationSeconds);
+      }),
+    );
+  }
+
+  private buildRouteLabel(req: any, fallbackPath: string | undefined): string {
+    const baseUrl = typeof req?.baseUrl === 'string' ? req.baseUrl : '';
+    const routePath = typeof req?.route?.path === 'string' ? req.route.path : '';
+    const composed = `${baseUrl}${routePath}`.trim();
+    if (composed) return composed;
+
+    const pathOnly = typeof fallbackPath === 'string' ? fallbackPath : 'unknown';
+    return pathOnly.split('?')[0] || 'unknown';
+  }
+}
+

--- a/harvest-finance/backend/src/observability/metrics/metrics.controller.ts
+++ b/harvest-finance/backend/src/observability/metrics/metrics.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Header } from '@nestjs/common';
+import { ApiExcludeEndpoint } from '@nestjs/swagger';
+import { MetricsService } from './metrics.service';
+
+@Controller('metrics')
+export class MetricsController {
+  constructor(private readonly metricsService: MetricsService) {}
+
+  @Get()
+  @ApiExcludeEndpoint()
+  @Header('Content-Type', MetricsService.contentType)
+  async getMetrics(): Promise<string> {
+    return this.metricsService.getMetrics();
+  }
+}
+

--- a/harvest-finance/backend/src/observability/metrics/metrics.module.ts
+++ b/harvest-finance/backend/src/observability/metrics/metrics.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { MetricsController } from './metrics.controller';
+import { MetricsService } from './metrics.service';
+import { HttpMetricsInterceptor } from './http-metrics.interceptor';
+
+@Module({
+  controllers: [MetricsController],
+  providers: [
+    MetricsService,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: HttpMetricsInterceptor,
+    },
+  ],
+  exports: [MetricsService],
+})
+export class MetricsModule {}
+

--- a/harvest-finance/backend/src/observability/metrics/metrics.service.ts
+++ b/harvest-finance/backend/src/observability/metrics/metrics.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import * as promClient from 'prom-client';
+
+@Injectable()
+export class MetricsService {
+  static readonly contentType = promClient.register.contentType;
+
+  readonly httpRequestsTotal: promClient.Counter<'method' | 'route' | 'status_code'>;
+  readonly httpRequestDurationSeconds: promClient.Histogram<
+    'method' | 'route' | 'status_code'
+  >;
+
+  constructor() {
+    this.httpRequestsTotal =
+      (promClient.register.getSingleMetric(
+        'http_requests_total',
+      ) as promClient.Counter<'method' | 'route' | 'status_code'>) ??
+      new promClient.Counter({
+        name: 'http_requests_total',
+        help: 'Total number of HTTP requests',
+        labelNames: ['method', 'route', 'status_code'] as const,
+      });
+
+    this.httpRequestDurationSeconds =
+      (promClient.register.getSingleMetric(
+        'http_request_duration_seconds',
+      ) as promClient.Histogram<'method' | 'route' | 'status_code'>) ??
+      new promClient.Histogram({
+        name: 'http_request_duration_seconds',
+        help: 'Duration of HTTP requests in seconds',
+        labelNames: ['method', 'route', 'status_code'] as const,
+        buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+      });
+  }
+
+  async getMetrics(): Promise<string> {
+    return promClient.register.metrics();
+  }
+}
+

--- a/harvest-finance/backend/src/observability/observability.module.ts
+++ b/harvest-finance/backend/src/observability/observability.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { MetricsModule } from './metrics/metrics.module';
+
+@Module({
+  imports: [MetricsModule],
+})
+export class ObservabilityModule {}
+

--- a/harvest-finance/backend/src/vaults/dto/batch-deposit.dto.ts
+++ b/harvest-finance/backend/src/vaults/dto/batch-deposit.dto.ts
@@ -1,0 +1,56 @@
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export class BatchDepositItemDto {
+  @ApiProperty({
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    description: 'Vault ID (UUID)',
+  })
+  @IsString()
+  @IsNotEmpty()
+  vaultId: string;
+
+  @ApiProperty({
+    example: 100.5,
+    description: 'Deposit amount (must be greater than 0)',
+    minimum: 0.01,
+  })
+  @IsNumber({ maxDecimalPlaces: 8 }, { message: 'Amount must be a number' })
+  @Min(0.01, { message: 'Deposit amount must be greater than 0' })
+  @Max(1000000, { message: 'Deposit amount cannot exceed 1,000,000' })
+  @IsNotEmpty({ message: 'Amount is required' })
+  amount: number;
+
+  @ApiProperty({
+    example: 'batch_item_key_1',
+    description: 'Unique key to prevent duplicate deposits per user (optional)',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  idempotencyKey?: string;
+}
+
+export class BatchDepositDto {
+  @ApiProperty({ type: [BatchDepositItemDto] })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(100)
+  @ValidateNested({ each: true })
+  @Type(() => BatchDepositItemDto)
+  deposits: BatchDepositItemDto[];
+}
+

--- a/harvest-finance/backend/src/vaults/dto/vault-response.dto.ts
+++ b/harvest-finance/backend/src/vaults/dto/vault-response.dto.ts
@@ -217,3 +217,17 @@ export class DepositVaultResponseDto {
   })
   userTotalDeposits: number;
 }
+
+export class BatchDepositResponseDto {
+  @ApiProperty({
+    description: 'Per-deposit results (in request order)',
+    type: [DepositVaultResponseDto],
+  })
+  results: DepositVaultResponseDto[];
+
+  @ApiProperty({
+    example: 25000.75,
+    description: "User's total deposits across all vaults after batch",
+  })
+  userTotalDeposits: number;
+}

--- a/harvest-finance/backend/src/vaults/events/withdrawal-confirmed.handler.ts
+++ b/harvest-finance/backend/src/vaults/events/withdrawal-confirmed.handler.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { NotificationsService } from '../../notifications/notifications.service';
+import { NotificationHelper } from '../../notifications/notification.helper';
+import { CustomLoggerService } from '../../logger/custom-logger.service';
+import { VaultGateway } from '../../realtime/vault.gateway';
+import {
+  DomainEventNames,
+  WithdrawalCompletedEvent,
+  WithdrawalConfirmedEvent,
+} from '../../domain-events';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+@Injectable()
+export class WithdrawalConfirmedHandler {
+  constructor(
+    private readonly notificationsService: NotificationsService,
+    private readonly logger: CustomLoggerService,
+    private readonly vaultGateway: VaultGateway,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  @OnEvent(DomainEventNames.WITHDRAWAL_CONFIRMED, { async: true })
+  async handle(event: WithdrawalConfirmedEvent): Promise<void> {
+    await this.notificationsService.create(
+      NotificationHelper.withdrawalConfirmed({
+        userId: event.userId,
+        amount: event.amount,
+        vaultName: event.vaultName,
+      }),
+    );
+
+    this.logger.log(
+      `Withdrawal of ${event.amount} confirmed from vault ${event.vaultId} by user ${event.userId}`,
+      'WithdrawalConfirmedHandler',
+    );
+
+    this.vaultGateway.emitWithdrawal({
+      vaultId: event.vaultId,
+      vaultName: event.vaultName,
+      amount: event.amount,
+      userId: event.userId,
+      newBalance: event.newBalance,
+    });
+
+    // Keep existing domain event for downstream consumers.
+    this.eventEmitter.emit(
+      DomainEventNames.WITHDRAWAL_COMPLETED,
+      new WithdrawalCompletedEvent(
+        event.withdrawalId,
+        event.userId,
+        event.vaultId,
+        event.amount,
+        event.vaultName,
+        event.newBalance,
+      ),
+    );
+  }
+}
+

--- a/harvest-finance/backend/src/vaults/vaults.controller.ts
+++ b/harvest-finance/backend/src/vaults/vaults.controller.ts
@@ -21,7 +21,9 @@ import {
 import { Throttle } from '@nestjs/throttler';
 import { VaultsService } from './vaults.service';
 import { DepositDto } from './dto/deposit.dto';
+import { BatchDepositDto } from './dto/batch-deposit.dto';
 import {
+  BatchDepositResponseDto,
   DepositVaultResponseDto,
   VaultResponseDto,
 } from './dto/vault-response.dto';
@@ -37,6 +39,23 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 @ApiBearerAuth()
 export class VaultsController {
   constructor(private readonly vaultsService: VaultsService) {}
+
+  @Post('deposits/batch')
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Submit multiple deposits atomically' })
+  @ApiBody({ type: BatchDepositDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Batch deposit processed successfully',
+    type: BatchDepositResponseDto,
+  })
+  async batchDeposit(
+    @Body() dto: BatchDepositDto,
+    @Request() req: any,
+  ): Promise<BatchDepositResponseDto> {
+    return this.vaultsService.batchDepositToVaults(req.user.id, dto);
+  }
 
   @Post(':vaultId/deposit')
   @Throttle({ default: { limit: 20, ttl: 60000 } })

--- a/harvest-finance/backend/src/vaults/vaults.module.ts
+++ b/harvest-finance/backend/src/vaults/vaults.module.ts
@@ -11,6 +11,7 @@ import { AuthModule } from '../auth/auth.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { RealtimeModule } from '../realtime/realtime.module';
 import { CommonModule } from '../common/common.module';
+import { WithdrawalConfirmedHandler } from './events/withdrawal-confirmed.handler';
 
 @Module({
   imports: [
@@ -21,7 +22,7 @@ import { CommonModule } from '../common/common.module';
     CommonModule,
   ],
   controllers: [VaultsController],
-  providers: [VaultsService, DepositEventService],
+  providers: [VaultsService, DepositEventService, WithdrawalConfirmedHandler],
   exports: [VaultsService, DepositEventService],
 })
 export class VaultsModule {}

--- a/harvest-finance/backend/src/vaults/vaults.service.ts
+++ b/harvest-finance/backend/src/vaults/vaults.service.ts
@@ -34,6 +34,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import {
   DepositCompletedEvent,
   DomainEventNames,
+  WithdrawalConfirmedEvent,
   WithdrawalCompletedEvent,
 } from '../domain-events';
 
@@ -678,37 +679,18 @@ export class VaultsService {
       throw new NotFoundException('Withdrawal not found after confirmation');
     }
 
-    await this.notificationsService.create(
-      NotificationHelper.withdrawalConfirmed({
-        userId,
-        amount,
-        vaultName: vault.vaultName,
-      }),
-    );
-
-    this.logger.log(
-      `Withdrawal of ${amount} confirmed from vault ${vaultId} by user ${userId}`,
-      'VaultsService',
-    );
-
-    this.vaultGateway.emitWithdrawal({
-      vaultId,
-      vaultName: vault.vaultName,
-      asset: vault.type,
-      amount,
-      userId,
-      newBalance: result.vault ? Number(result.vault.totalDeposits) : 0,
-    });
-
+    // Emit an async event for post-confirmation work (notifications, realtime, downstream domain events).
     this.eventEmitter.emit(
-      DomainEventNames.WITHDRAWAL_COMPLETED,
-      new WithdrawalCompletedEvent(
+      DomainEventNames.WITHDRAWAL_CONFIRMED,
+      new WithdrawalConfirmedEvent(
         confirmedWithdrawal.id,
         userId,
         vaultId,
         amount,
         vault.vaultName,
         result.vault ? Number(result.vault.totalDeposits) : 0,
+        confirmedWithdrawal.transactionHash,
+        confirmedWithdrawal.confirmedAt ?? new Date(),
       ),
     );
 

--- a/harvest-finance/backend/src/vaults/vaults.service.ts
+++ b/harvest-finance/backend/src/vaults/vaults.service.ts
@@ -14,6 +14,7 @@ import {
   WithdrawalStatus,
 } from '../database/entities/withdrawal.entity';
 import { DepositDto } from './dto/deposit.dto';
+import { BatchDepositDto } from './dto/batch-deposit.dto';
 import {
   DepositVaultResponseDto,
   VaultResponseDto,
@@ -220,6 +221,234 @@ export class VaultsService {
       deposit: this.mapDepositToResponse(confirmedDeposit),
       userTotalDeposits,
     };
+  }
+
+  async batchDepositToVaults(
+    userId: string,
+    dto: BatchDepositDto,
+  ): Promise<{ results: DepositVaultResponseDto[]; userTotalDeposits: number }> {
+    const deposits = dto.deposits ?? [];
+    if (deposits.length === 0) {
+      throw new BadRequestException('At least one deposit is required');
+    }
+
+    // Minimal dedupe check: idempotencyKey duplicates within the same request.
+    const keys = deposits
+      .map((d) => d.idempotencyKey)
+      .filter((k): k is string => typeof k === 'string' && k.length > 0);
+    const uniqueKeys = new Set(keys);
+    if (uniqueKeys.size !== keys.length) {
+      throw new BadRequestException('Duplicate idempotencyKey in batch request');
+    }
+
+    const results = await this.dataSource.transaction(async (manager) => {
+      // Load and validate all vaults up front.
+      const uniqueVaultIds = Array.from(new Set(deposits.map((d) => d.vaultId)));
+      const vaults = await manager.find(Vault, {
+        where: uniqueVaultIds.map((id) => ({ id })),
+      });
+      const vaultById = new Map(vaults.map((v) => [v.id, v]));
+
+      for (const vaultId of uniqueVaultIds) {
+        if (!vaultById.has(vaultId)) {
+          throw new NotFoundException(`Vault not found: ${vaultId}`);
+        }
+      }
+
+      // Aggregate requested amounts per vault so we can fail-fast on capacity.
+      const totalByVault = new Map<string, number>();
+      for (const item of deposits) {
+        const amount = item.amount;
+        if (amount <= 0) {
+          throw new BadRequestException('Deposit amount must be greater than 0');
+        }
+        if (amount > MAX_SAFE_DEPOSIT) {
+          throw new BadRequestException(
+            'Deposit amount exceeds maximum allowed value',
+          );
+        }
+        totalByVault.set(item.vaultId, (totalByVault.get(item.vaultId) ?? 0) + amount);
+      }
+
+      for (const [vaultId, totalAmount] of totalByVault.entries()) {
+        const vault = vaultById.get(vaultId)!;
+        if (vault.status !== VaultStatus.ACTIVE) {
+          throw new BadRequestException(
+            `Vault is not active for deposits: ${vaultId}`,
+          );
+        }
+        if (vault.isFullCapacity) {
+          throw new BadRequestException(
+            `Vault has reached maximum capacity: ${vaultId}`,
+          );
+        }
+        if (totalAmount > vault.availableCapacity) {
+          throw new BadRequestException(
+            `Batch deposits exceed available vault capacity for ${vaultId}. Available: ${vault.availableCapacity}`,
+          );
+        }
+      }
+
+      // Idempotency: if any requested idempotencyKey already exists, fail the whole batch.
+      if (uniqueKeys.size > 0) {
+        const existing = await manager.find(Deposit, {
+          where: Array.from(uniqueKeys).map((key) => ({ userId, idempotencyKey: key })),
+          relations: ['vault'],
+        });
+        if (existing.length > 0) {
+          const first = existing[0];
+          throw new BadRequestException(
+            `Duplicate deposit detected with idempotencyKey: ${first.idempotencyKey}`,
+          );
+        }
+      }
+
+      const perDepositResponses: DepositVaultResponseDto[] = [];
+
+      // Create + confirm each deposit within the same transaction for atomicity.
+      for (const item of deposits) {
+        const deposit = manager.getRepository(Deposit).create({
+          userId,
+          vaultId: item.vaultId,
+          amount: item.amount,
+          status: DepositStatus.PENDING,
+          transactionHash: null,
+          stellarTransactionId: null,
+          confirmedAt: null,
+          idempotencyKey: item.idempotencyKey || null,
+        });
+
+        const savedDeposit = await manager.save(deposit);
+
+        await this.depositEventService.appendEvent(
+          {
+            depositId: savedDeposit.id,
+            userId,
+            vaultId: item.vaultId,
+            eventType: DepositEventType.INITIATED,
+            amount: item.amount,
+            idempotencyKey: item.idempotencyKey || null,
+            payload: { status: DepositStatus.PENDING },
+          },
+          manager,
+        );
+
+        await manager.increment(
+          Vault,
+          { id: item.vaultId },
+          'totalDeposits',
+          item.amount,
+        );
+
+        const stellarTransactionId: string | null = `mock_stellar_${Date.now()}`;
+        const transactionHash = `mock_tx_${Date.now()}`;
+        const confirmedAt = new Date();
+
+        await manager.update(Deposit, savedDeposit.id, {
+          status: DepositStatus.CONFIRMED,
+          confirmedAt,
+          transactionHash,
+          ...(stellarTransactionId != null ? { stellarTransactionId } : {}),
+        });
+
+        await this.depositEventService.appendEvent(
+          {
+            depositId: savedDeposit.id,
+            userId,
+            vaultId: item.vaultId,
+            eventType: DepositEventType.CONFIRMED,
+            amount: item.amount,
+            transactionHash,
+            stellarTransactionId,
+            idempotencyKey: item.idempotencyKey || null,
+            payload: {
+              status: DepositStatus.CONFIRMED,
+              confirmedAt: confirmedAt.toISOString(),
+            },
+          },
+          manager,
+        );
+
+        const updatedVault = await manager.findOne(Vault, {
+          where: { id: item.vaultId },
+        });
+
+        if (updatedVault && updatedVault.isFullCapacity) {
+          await manager.update(
+            Vault,
+            { id: item.vaultId },
+            { status: VaultStatus.FULL_CAPACITY },
+          );
+          updatedVault.status = VaultStatus.FULL_CAPACITY;
+        }
+
+        const confirmedDeposit = await manager.findOne(Deposit, {
+          where: { id: savedDeposit.id },
+        });
+
+        if (!confirmedDeposit) {
+          throw new NotFoundException('Deposit not found after confirmation');
+        }
+
+        const userTotalDeposits = await manager
+          .getRepository(Deposit)
+          .createQueryBuilder('deposit')
+          .select('SUM(deposit.amount)', 'total')
+          .where('deposit.userId = :userId', { userId })
+          .andWhere('deposit.status = :status', { status: DepositStatus.CONFIRMED })
+          .getRawOne();
+
+        perDepositResponses.push({
+          vault: updatedVault ? this.mapVaultToResponse(updatedVault) : null,
+          deposit: this.mapDepositToResponse(confirmedDeposit),
+          userTotalDeposits: userTotalDeposits?.total
+            ? parseFloat(userTotalDeposits.total)
+            : 0,
+        });
+      }
+
+      return perDepositResponses;
+    });
+
+    // Post-transaction: recompute total deposits and emit events/notifications asynchronously.
+    const userTotalDeposits = await this.getUserTotalDeposits(userId);
+
+    for (const r of results) {
+      const amount = r.deposit.amount;
+      if (amount >= LARGE_DEPOSIT_THRESHOLD && r.vault) {
+        await this.notificationsService.create(
+          NotificationHelper.largeDepositAlert({
+            amount,
+            vaultName: r.vault.vaultName,
+          }),
+        );
+      }
+
+      if (r.vault) {
+        this.vaultGateway.emitDeposit({
+          vaultId: r.vault.id,
+          vaultName: r.vault.vaultName,
+          asset: r.vault.type,
+          amount,
+          userId,
+          newBalance: r.vault.totalDeposits,
+        });
+
+        this.eventEmitter.emit(
+          DomainEventNames.DEPOSIT_COMPLETED,
+          new DepositCompletedEvent(
+            r.deposit.id,
+            userId,
+            r.vault.id,
+            amount,
+            r.vault.vaultName,
+            r.vault.totalDeposits,
+          ),
+        );
+      }
+    }
+
+    return { results, userTotalDeposits };
   }
 
   private async confirmDeposit(depositId: string): Promise<Deposit> {


### PR DESCRIPTION
## Summary
- Added Prometheus-compatible /metrics endpoint with baseline HTTP request counters and latency histogram (http_requests_total, http_request_duration_seconds).
- Implemented atomic batch deposit API: POST /vaults/deposits/batch, inserting deposits and related events inside a single database transaction.
- Refactored withdrawal post-confirmation work to async domain events by emitting WithdrawalConfirmedEvent and handling notifications/realtime updates in an async event handler (covers both Task 3 and duplicate Task 4).

## Endpoints
- GET /metrics
- POST /vaults/deposits/batch
- 

Closes #424 
Closes #427 
Closes #428 
Closes #429  