### PR TITLE
feat(vaults): implement vault cloning from template (#440)

### DIFF
--- a/PR_DESCRIPTION_440.md
+++ b/PR_DESCRIPTION_440.md
@@ -1,0 +1,34 @@
+## Summary
+Adds an API for vault owners to create a new vault by cloning an existing vault's configuration (type, capacity, rates, metadata, and multi-sig settings) while resetting all financial state.
+
+## Purpose / Motivation
+Power users who run multiple similar vaults previously had to re-enter the same settings manually. Cloning copies the template configuration in one step and starts the new vault with zero deposits and a fresh approval count.
+
+## Changes Made
+- #440: `POST /v1/vaults/:vaultId/clone` — authenticated endpoint for vault owners
+- `VaultsService.cloneVaultFromTemplate` — deep-copies config fields; resets `totalDeposits`, `status` (ACTIVE), and `currentApprovals`
+- `CloneVaultDto` — optional custom `vaultName` (defaults to `{source name} (Copy)`)
+- Integration tests for success, custom name, not found, and unauthorized clone
+
+## How to Test
+1. Authenticate as a user who owns a vault with non-default settings (capacity, interest, multi-sig, etc.).
+2. `POST /v1/vaults/{vaultId}/clone` with an empty body or `{ "vaultName": "My Clone" }`.
+3. Expect `201` and a new vault ID with matching config but `totalDeposits: 0`, `status: ACTIVE`, `currentApprovals: 0`.
+4. `GET /v1/vaults/my-vaults` — confirm both source and clone appear.
+5. Clone another user's vault — expect `401`.
+6. Clone a non-existent vault ID — expect `404`.
+
+## Screenshots (if applicable)
+N/A — API-only change.
+
+## Breaking Changes
+- None.
+
+## Related Issues
+Closes code-flexing/Harvest-Finance#440
+
+## Checklist
+- [x] Code builds successfully
+- [x] Tests added/updated
+- [ ] No console errors
+- [ ] Documentation updated (if needed)

--- a/harvest-finance/backend/src/vaults/dto/clone-vault.dto.ts
+++ b/harvest-finance/backend/src/vaults/dto/clone-vault.dto.ts
@@ -1,0 +1,14 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CloneVaultDto {
+  @ApiPropertyOptional({
+    example: 'Corn High Yield Vault (Copy)',
+    description:
+      'Optional name for the cloned vault. Defaults to "{source name} (Copy)".',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  vaultName?: string;
+}

--- a/harvest-finance/backend/src/vaults/vaults.controller.ts
+++ b/harvest-finance/backend/src/vaults/vaults.controller.ts
@@ -27,6 +27,7 @@ import { GetVaultBalanceQuery } from './cqrs/queries/get-vault-balance.query';
 import { GetVaultTransactionsQuery } from './cqrs/queries/get-vault-transactions.query';
 import { DepositDto } from './dto/deposit.dto';
 import { BatchDepositDto } from './dto/batch-deposit.dto';
+import { CloneVaultDto } from './dto/clone-vault.dto';
 import {
   BatchDepositResponseDto,
   DepositVaultResponseDto,
@@ -207,6 +208,40 @@ export class VaultsController {
     @Param('vaultId') vaultId: string,
   ): Promise<DepositEventResponseDto[]> {
     return this.vaultsService.getVaultDepositEventHistory(vaultId);
+  }
+
+  @Post(':vaultId/clone')
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Clone vault configuration from an existing template vault',
+  })
+  @ApiParam({
+    name: 'vaultId',
+    description: 'Source vault ID (UUID) to copy configuration from',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @ApiBody({ type: CloneVaultDto, required: false })
+  @ApiResponse({
+    status: 201,
+    description: 'Vault cloned successfully',
+    type: VaultResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - Only vault owner can clone',
+  })
+  @ApiResponse({ status: 404, description: 'Vault not found' })
+  async cloneVault(
+    @Param('vaultId') vaultId: string,
+    @Body() cloneVaultDto: CloneVaultDto,
+    @Request() req: any,
+  ): Promise<VaultResponseDto> {
+    return this.vaultsService.cloneVaultFromTemplate(
+      vaultId,
+      req.user.id,
+      cloneVaultDto?.vaultName,
+    );
   }
 
   @Get('my-vaults')

--- a/harvest-finance/backend/src/vaults/vaults.integration.spec.ts
+++ b/harvest-finance/backend/src/vaults/vaults.integration.spec.ts
@@ -1,7 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { VaultsService } from './vaults.service';
 import {
   Vault,
@@ -21,7 +26,9 @@ import { InputSanitizerService } from '../common/sanitization/input-sanitizer.se
 import { DepositEventService } from './deposit-event.service';
 
 const USER_ID = '11111111-1111-1111-1111-111111111111';
+const OTHER_USER_ID = '99999999-9999-9999-9999-999999999999';
 const VAULT_ID = '22222222-2222-2222-2222-222222222222';
+const CLONED_VAULT_ID = '55555555-5555-5555-5555-555555555555';
 const DEPOSIT_ID = '33333333-3333-3333-3333-333333333333';
 const WITHDRAWAL_ID = '44444444-4444-4444-4444-444444444444';
 
@@ -33,11 +40,16 @@ const buildVault = (
   type: VaultType.CROP_PRODUCTION,
   status: VaultStatus.ACTIVE,
   vaultName: 'Harvest Yield Vault',
-  description: null,
-  totalDeposits: 0,
+  description: 'Template vault',
+  symbol: 'HVF',
+  assetPair: 'XLM/USDC',
+  totalDeposits: 5000,
   maxCapacity: 10000,
   interestRate: 5,
   isPublic: true,
+  requiresMultiSignature: true,
+  approvalThreshold: 2,
+  currentApprovals: 1,
   maturityDate: null,
   lockPeriodEnd: null,
   deposits: [],
@@ -69,6 +81,12 @@ describe('VaultsService — Yield Strategy Integration', () => {
   const mockVaultRepository = {
     findOne: jest.fn(),
     find: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockEventEmitter = {
+    emit: jest.fn(),
   };
 
   const mockDepositRepository = {
@@ -128,6 +146,7 @@ describe('VaultsService — Yield Strategy Integration', () => {
         { provide: ContractCacheService, useValue: mockContractCache },
         { provide: InputSanitizerService, useValue: mockSanitizer },
         { provide: DepositEventService, useValue: mockDepositEventService },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
       ],
     }).compile();
 
@@ -640,6 +659,97 @@ describe('VaultsService — Yield Strategy Integration', () => {
       const result = await service.getPublicVaults();
 
       expect(result).toEqual([]);
+    });
+  });
+
+  // ── Vault cloning ──────────────────────────────────────────────────────────
+
+  describe('cloneVaultFromTemplate', () => {
+    it('should create a new vault with copied config and reset financial state', async () => {
+      const sourceVault = buildVault({
+        status: VaultStatus.FULL_CAPACITY,
+        totalDeposits: 5000,
+      });
+      const savedClone = buildVault({
+        id: CLONED_VAULT_ID,
+        vaultName: 'Harvest Yield Vault (Copy)',
+        status: VaultStatus.ACTIVE,
+        totalDeposits: 0,
+        currentApprovals: 0,
+        availableCapacity: 10000,
+        utilizationPercentage: 0,
+        isFullCapacity: false,
+      });
+
+      mockVaultRepository.findOne.mockResolvedValue(sourceVault);
+      mockVaultRepository.create.mockImplementation((data) => data);
+      mockVaultRepository.save.mockResolvedValue(savedClone);
+
+      const result = await service.cloneVaultFromTemplate(VAULT_ID, USER_ID);
+
+      expect(mockVaultRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ownerId: USER_ID,
+          type: VaultType.CROP_PRODUCTION,
+          status: VaultStatus.ACTIVE,
+          vaultName: 'Harvest Yield Vault (Copy)',
+          description: 'Template vault',
+          symbol: 'HVF',
+          assetPair: 'XLM/USDC',
+          totalDeposits: 0,
+          maxCapacity: 10000,
+          interestRate: 5,
+          requiresMultiSignature: true,
+          approvalThreshold: 2,
+          currentApprovals: 0,
+        }),
+      );
+      expect(result.id).toBe(CLONED_VAULT_ID);
+      expect(result.totalDeposits).toBe(0);
+      expect(result.status).toBe(VaultStatus.ACTIVE);
+    });
+
+    it('should use a custom vault name when provided', async () => {
+      const sourceVault = buildVault();
+      const savedClone = buildVault({
+        id: CLONED_VAULT_ID,
+        vaultName: 'My Custom Clone',
+        totalDeposits: 0,
+        currentApprovals: 0,
+      });
+
+      mockVaultRepository.findOne.mockResolvedValue(sourceVault);
+      mockVaultRepository.create.mockImplementation((data) => data);
+      mockVaultRepository.save.mockResolvedValue(savedClone);
+
+      const result = await service.cloneVaultFromTemplate(
+        VAULT_ID,
+        USER_ID,
+        'My Custom Clone',
+      );
+
+      expect(mockVaultRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ vaultName: 'My Custom Clone' }),
+      );
+      expect(result.vaultName).toBe('My Custom Clone');
+    });
+
+    it('should throw NotFoundException when source vault does not exist', async () => {
+      mockVaultRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.cloneVaultFromTemplate(VAULT_ID, USER_ID),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw UnauthorizedException when user is not the owner', async () => {
+      mockVaultRepository.findOne.mockResolvedValue(
+        buildVault({ ownerId: OTHER_USER_ID }),
+      );
+
+      await expect(
+        service.cloneVaultFromTemplate(VAULT_ID, USER_ID),
+      ).rejects.toThrow(UnauthorizedException);
     });
   });
 

--- a/harvest-finance/backend/src/vaults/vaults.service.ts
+++ b/harvest-finance/backend/src/vaults/vaults.service.ts
@@ -565,6 +565,60 @@ export class VaultsService {
     return vaults.map((vault) => this.mapVaultToResponse(vault));
   }
 
+  /**
+   * Creates a new vault by deep-copying configuration from an existing vault.
+   * Financial state (deposits, approvals, balances) is reset on the clone.
+   */
+  async cloneVaultFromTemplate(
+    sourceVaultId: string,
+    userId: string,
+    vaultName?: string,
+  ): Promise<VaultResponseDto> {
+    const sanitizedSourceId = this.sanitizer.validateUUID(sourceVaultId);
+    const sourceVault = await this.vaultRepository.findOne({
+      where: { id: sanitizedSourceId },
+    });
+
+    if (!sourceVault) {
+      throw new NotFoundException('Vault not found');
+    }
+
+    if (sourceVault.ownerId !== userId) {
+      throw new UnauthorizedException(
+        'Only the vault owner can clone this vault',
+      );
+    }
+
+    const resolvedName = (vaultName?.trim() ||
+      `${sourceVault.vaultName} (Copy)`).slice(0, 100);
+
+    if (!resolvedName) {
+      throw new BadRequestException('Vault name is required');
+    }
+
+    const clonedVault = this.vaultRepository.create({
+      ownerId: userId,
+      type: sourceVault.type,
+      status: VaultStatus.ACTIVE,
+      vaultName: resolvedName,
+      description: sourceVault.description,
+      symbol: sourceVault.symbol,
+      assetPair: sourceVault.assetPair,
+      totalDeposits: 0,
+      maxCapacity: sourceVault.maxCapacity,
+      interestRate: sourceVault.interestRate,
+      maturityDate: sourceVault.maturityDate,
+      lockPeriodEnd: sourceVault.lockPeriodEnd,
+      isPublic: sourceVault.isPublic,
+      requiresMultiSignature: sourceVault.requiresMultiSignature,
+      approvalThreshold: sourceVault.approvalThreshold,
+      currentApprovals: 0,
+    });
+
+    const saved = await this.vaultRepository.save(clonedVault);
+    return this.mapVaultToResponse(saved);
+  }
+
   async getPublicVaults(): Promise<VaultResponseDto[]> {
     const vaults = await this.vaultRepository.find({
       where: { isPublic: true },


### PR DESCRIPTION
## Summary
Adds an API for vault owners to create a new vault by cloning an existing vault's configuration (type, capacity, rates, metadata, and multi-sig settings) while resetting all financial state.

## Purpose / Motivation
Power users who run multiple similar vaults previously had to re-enter the same settings manually. Cloning copies the template configuration in one step and starts the new vault with zero deposits and a fresh approval count.

## Changes Made
- #440: `POST /v1/vaults/:vaultId/clone` — authenticated endpoint for vault owners
- `VaultsService.cloneVaultFromTemplate` — deep-copies config fields; resets `totalDeposits`, `status` (ACTIVE), and `currentApprovals`
- `CloneVaultDto` — optional custom `vaultName` (defaults to `{source name} (Copy)`)
- Integration tests for success, custom name, not found, and unauthorized clone

## How to Test
1. Authenticate as a user who owns a vault with non-default settings (capacity, interest, multi-sig, etc.).
2. `POST /v1/vaults/{vaultId}/clone` with an empty body or `{ "vaultName": "My Clone" }`.
3. Expect `201` and a new vault ID with matching config but `totalDeposits: 0`, `status: ACTIVE`, `currentApprovals: 0`.
4. `GET /v1/vaults/my-vaults` — confirm both source and clone appear.
5. Clone another user's vault — expect `401`.
6. Clone a non-existent vault ID — expect `404`.

## Screenshots (if applicable)
N/A — API-only change.

## Breaking Changes
- None.

## Related Issues
Closes code-flexing/Harvest-Finance#440

## Checklist
- [x] Code builds successfully
- [x] Tests added/updated
- [ ] No console errors
- [ ] Documentation updated (if needed)