### PR TITLE
feat(webhooks): add HMAC-signed payment and chain event endpoints

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -117,6 +117,47 @@ Returns indexer status: enabled, last ledger, total events.
 
 ---
 
+## Webhooks
+
+External systems push events to these endpoints. Each request must include an HMAC-SHA256 signature of the **raw JSON body** in the `x-webhook-signature` header (`sha256=<hex>`).
+
+### POST /webhooks/payments
+Payment provider confirmation (requires `WEBHOOK_PAYMENTS_HMAC_SECRET` on the server).
+
+```json
+{
+  "eventId": "evt_unique_123",
+  "eventType": "payment.confirmed",
+  "depositId": "uuid",
+  "transactionHash": "abc123",
+  "stellarTransactionId": "optional-stellar-tx-id",
+  "occurredAt": "2026-06-02T10:00:00.000Z"
+}
+```
+
+`eventType` may also be `payment.failed`.
+
+**Response:** `{ "accepted": true, "eventId": "...", "duplicate": false }`
+
+### POST /webhooks/chain-events
+Chain indexer event ingestion (requires `WEBHOOK_CHAIN_EVENTS_HMAC_SECRET` on the server).
+
+```json
+{
+  "eventId": "chain_evt_123",
+  "type": "contract",
+  "contractId": "CABC...",
+  "ledger": 12345,
+  "ledgerClosedAt": "2026-06-02T10:00:00.000Z",
+  "transactionHash": "tx_hash",
+  "pagingToken": "paging_token",
+  "topics": [],
+  "value": {}
+}
+```
+
+---
+
 ## Health
 
 ### GET /health

--- a/harvest-finance/backend/src/app.module.ts
+++ b/harvest-finance/backend/src/app.module.ts
@@ -81,6 +81,7 @@ import { CreateYieldAnalytics1700000000012 } from './database/migrations/1700000
 import { AddSorobanEventQueryIndexes1700000000013 } from './database/migrations/1700000000013-AddSorobanEventQueryIndexes';
 import { CreateDepositEvents1700000000016 } from './database/migrations/1700000000016-CreateDepositEvents';
 import { DomainEventsModule } from './domain-events';
+import { WebhooksModule } from './webhooks/webhooks.module';
 
 @Module({
   imports: [
@@ -173,6 +174,7 @@ import { DomainEventsModule } from './domain-events';
     PortfolioModule,
     AnalyticsModule,
     StateSyncModule,
+    WebhooksModule,
   ],
   controllers: [AppController],
   providers: [

--- a/harvest-finance/backend/src/common/config/env.validation.ts
+++ b/harvest-finance/backend/src/common/config/env.validation.ts
@@ -46,6 +46,12 @@ export function validateEnvironment(
       THROTTLE_LIMIT: num({ default: 100 }),
       LOG_LEVEL: str({ choices: logLevels, default: 'info' }),
       LOG_PRETTY: bool({ default: false, devDefault: true }),
+      WEBHOOK_PAYMENTS_HMAC_SECRET: str({
+        devDefault: 'dev-webhook-payments-secret',
+      }),
+      WEBHOOK_CHAIN_EVENTS_HMAC_SECRET: str({
+        devDefault: 'dev-webhook-chain-events-secret',
+      }),
     },
     {
       reporter: ({ errors }) => {

--- a/harvest-finance/backend/src/main.ts
+++ b/harvest-finance/backend/src/main.ts
@@ -18,6 +18,7 @@ import { ResponseInterceptor } from './common/interceptors/response.interceptor'
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     bufferLogs: true,
+    rawBody: true,
   });
   const customLogger = app.get(CustomLoggerService);
   app.useLogger(customLogger);
@@ -113,6 +114,10 @@ async function bootstrap() {
       'Cross-chain yield aggregation across registered chain adapters',
     )
     .addTag('health', 'Health check endpoints')
+    .addTag(
+      'Webhooks',
+      'HMAC-signed endpoints for external payment and chain event notifications',
+    )
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api/docs', app, document, {

--- a/harvest-finance/backend/src/soroban/soroban-indexer.service.ts
+++ b/harvest-finance/backend/src/soroban/soroban-indexer.service.ts
@@ -281,6 +281,42 @@ export class SorobanIndexerService implements OnModuleInit {
   }
 
   /**
+   * Ingests a chain event pushed by an external webhook provider.
+   * Uses the same idempotent upsert path as the background indexer.
+   */
+  async ingestExternalEvent(event: {
+    eventId: string;
+    type: SorobanEventType;
+    contractId?: string;
+    ledger: number;
+    ledgerClosedAt: string;
+    transactionHash?: string;
+    pagingToken: string;
+    topics?: string[];
+    value?: unknown;
+    inSuccessfulContractCall?: boolean;
+  }): Promise<{ stored: boolean }> {
+    const entity = new SorobanEvent();
+    entity.eventId = event.eventId;
+    entity.type = event.type;
+    entity.contractId = event.contractId ?? null;
+    entity.ledger = event.ledger;
+    entity.ledgerClosedAt = new Date(event.ledgerClosedAt);
+    entity.transactionHash = event.transactionHash ?? null;
+    entity.pagingToken = event.pagingToken;
+    entity.topics = event.topics ?? [];
+    entity.value = event.value ?? null;
+    entity.inSuccessfulContractCall = event.inSuccessfulContractCall ?? true;
+
+    const stored = await this.persist([entity]);
+    if (stored > 0 && entity.ledger > (this.lastIndexedLedger ?? 0)) {
+      this.lastIndexedLedger = entity.ledger;
+    }
+
+    return { stored: stored > 0 };
+  }
+
+  /**
    * Get the latest ledger from the Soroban RPC
    */
   async getLatestLedger(): Promise<number> {

--- a/harvest-finance/backend/src/vaults/dto/external-payment-notification.dto.ts
+++ b/harvest-finance/backend/src/vaults/dto/external-payment-notification.dto.ts
@@ -1,0 +1,4 @@
+export enum ExternalPaymentEventType {
+  PAYMENT_CONFIRMED = 'payment.confirmed',
+  PAYMENT_FAILED = 'payment.failed',
+}

--- a/harvest-finance/backend/src/vaults/vaults.service.ts
+++ b/harvest-finance/backend/src/vaults/vaults.service.ts
@@ -9,6 +9,7 @@ import { Repository, DataSource } from 'typeorm';
 import { Vault, VaultStatus } from '../database/entities/vault.entity';
 import { Deposit, DepositStatus } from '../database/entities/deposit.entity';
 import { DepositEventType } from '../database/entities/deposit-event.entity';
+import { ExternalPaymentEventType } from './dto/external-payment-notification.dto';
 import {
   Withdrawal,
   WithdrawalStatus,
@@ -453,6 +454,32 @@ export class VaultsService {
   }
 
   private async confirmDeposit(depositId: string): Promise<Deposit> {
+    const { deposit } = await this.applyExternalPaymentNotification({
+      depositId,
+      eventType: ExternalPaymentEventType.PAYMENT_CONFIRMED,
+      transactionHash: `mock_tx_${Date.now()}`,
+      stellarTransactionId: `mock_stellar_${Date.now()}`,
+      externalEventId: `internal_confirm_${depositId}`,
+    });
+    return deposit;
+  }
+
+  /**
+   * Applies payment status updates from external webhook providers.
+   */
+  async applyExternalPaymentNotification(params: {
+    depositId: string;
+    eventType: ExternalPaymentEventType;
+    transactionHash: string;
+    stellarTransactionId?: string | null;
+    externalEventId: string;
+    occurredAt?: Date;
+  }): Promise<{
+    deposit: Deposit;
+    status: DepositStatus;
+    duplicate: boolean;
+  }> {
+    const depositId = this.sanitizer.validateUUID(params.depositId);
     const deposit = await this.depositRepository.findOne({
       where: { id: depositId },
     });
@@ -461,49 +488,108 @@ export class VaultsService {
       throw new NotFoundException('Deposit not found');
     }
 
-    const stellarTransactionId: string | null = `mock_stellar_${Date.now()}`;
-    const transactionHash = `mock_tx_${Date.now()}`;
-    const confirmedAt = new Date();
+    if (params.eventType === ExternalPaymentEventType.PAYMENT_CONFIRMED) {
+      if (deposit.status === DepositStatus.CONFIRMED) {
+        return {
+          deposit,
+          status: deposit.status,
+          duplicate: true,
+        };
+      }
+
+      const confirmedAt = params.occurredAt ?? new Date();
+      const stellarTransactionId = params.stellarTransactionId ?? null;
+
+      await this.depositRepository.update(depositId, {
+        status: DepositStatus.CONFIRMED,
+        confirmedAt,
+        transactionHash: params.transactionHash,
+        ...(stellarTransactionId != null ? { stellarTransactionId } : {}),
+      });
+
+      await this.depositEventService.appendEvent({
+        depositId,
+        userId: deposit.userId,
+        vaultId: deposit.vaultId,
+        eventType: DepositEventType.CONFIRMED,
+        amount: Number(deposit.amount),
+        transactionHash: params.transactionHash,
+        stellarTransactionId,
+        idempotencyKey: deposit.idempotencyKey,
+        payload: {
+          status: DepositStatus.CONFIRMED,
+          confirmedAt: confirmedAt.toISOString(),
+          externalEventId: params.externalEventId,
+        },
+      });
+
+      const updatedDeposit = await this.depositRepository.findOne({
+        where: { id: depositId },
+      });
+
+      if (!updatedDeposit) {
+        throw new NotFoundException('Deposit not found after confirmation');
+      }
+
+      await this.notificationsService.create(
+        NotificationHelper.depositConfirmed({
+          userId: updatedDeposit.userId,
+          amount: updatedDeposit.amount,
+          vaultId: updatedDeposit.vaultId,
+        }),
+      );
+
+      return {
+        deposit: updatedDeposit,
+        status: DepositStatus.CONFIRMED,
+        duplicate: false,
+      };
+    }
+
+    if (deposit.status === DepositStatus.FAILED) {
+      return {
+        deposit,
+        status: deposit.status,
+        duplicate: true,
+      };
+    }
 
     await this.depositRepository.update(depositId, {
-      status: DepositStatus.CONFIRMED,
-      confirmedAt,
-      transactionHash,
-      ...(stellarTransactionId != null ? { stellarTransactionId } : {}),
+      status: DepositStatus.FAILED,
+      transactionHash: params.transactionHash,
+      ...(params.stellarTransactionId != null
+        ? { stellarTransactionId: params.stellarTransactionId }
+        : {}),
     });
 
     await this.depositEventService.appendEvent({
       depositId,
       userId: deposit.userId,
       vaultId: deposit.vaultId,
-      eventType: DepositEventType.CONFIRMED,
+      eventType: DepositEventType.FAILED,
       amount: Number(deposit.amount),
-      transactionHash,
-      stellarTransactionId,
+      transactionHash: params.transactionHash,
+      stellarTransactionId: params.stellarTransactionId ?? null,
       idempotencyKey: deposit.idempotencyKey,
       payload: {
-        status: DepositStatus.CONFIRMED,
-        confirmedAt: confirmedAt.toISOString(),
+        status: DepositStatus.FAILED,
+        externalEventId: params.externalEventId,
       },
     });
 
-    const updatedDeposit = await this.depositRepository.findOne({
+    const failedDeposit = await this.depositRepository.findOne({
       where: { id: depositId },
     });
 
-    if (!updatedDeposit) {
-      throw new NotFoundException('Deposit not found after confirmation');
+    if (!failedDeposit) {
+      throw new NotFoundException('Deposit not found after failure update');
     }
 
-    await this.notificationsService.create(
-      NotificationHelper.depositConfirmed({
-        userId: updatedDeposit.userId,
-        amount: updatedDeposit.amount,
-        vaultId: updatedDeposit.vaultId,
-      }),
-    );
-
-    return updatedDeposit;
+    return {
+      deposit: failedDeposit,
+      status: DepositStatus.FAILED,
+      duplicate: false,
+    };
   }
 
   async getDepositEventHistory(

--- a/harvest-finance/backend/src/webhooks/constants.ts
+++ b/harvest-finance/backend/src/webhooks/constants.ts
@@ -1,0 +1,10 @@
+export const WEBHOOK_HMAC_KEY = 'webhook_hmac_secret';
+
+export const WEBHOOK_SIGNATURE_HEADER = 'x-webhook-signature';
+
+export type WebhookSecretKind = 'payments' | 'chain-events';
+
+export const WEBHOOK_SECRET_ENV: Record<WebhookSecretKind, string> = {
+  payments: 'WEBHOOK_PAYMENTS_HMAC_SECRET',
+  'chain-events': 'WEBHOOK_CHAIN_EVENTS_HMAC_SECRET',
+};

--- a/harvest-finance/backend/src/webhooks/decorators/webhook-hmac.decorator.ts
+++ b/harvest-finance/backend/src/webhooks/decorators/webhook-hmac.decorator.ts
@@ -1,0 +1,12 @@
+import { SetMetadata, UseGuards, applyDecorators } from '@nestjs/common';
+import {
+  WEBHOOK_HMAC_KEY,
+  WebhookSecretKind,
+} from '../constants';
+import { WebhookSignatureGuard } from '../guards/webhook-signature.guard';
+
+export const WebhookHmac = (kind: WebhookSecretKind) =>
+  applyDecorators(
+    SetMetadata(WEBHOOK_HMAC_KEY, kind),
+    UseGuards(WebhookSignatureGuard),
+  );

--- a/harvest-finance/backend/src/webhooks/dto/chain-event-webhook.dto.ts
+++ b/harvest-finance/backend/src/webhooks/dto/chain-event-webhook.dto.ts
@@ -1,0 +1,63 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsISO8601,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+import { SorobanEventType } from '../../database/entities/soroban-event.entity';
+
+export class ChainEventWebhookDto {
+  @ApiProperty({ description: 'Unique event identifier from the chain indexer' })
+  @IsString()
+  @IsNotEmpty()
+  eventId: string;
+
+  @ApiProperty({ enum: SorobanEventType })
+  @IsEnum(SorobanEventType)
+  type: SorobanEventType;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  contractId?: string;
+
+  @ApiProperty({ minimum: 1 })
+  @IsInt()
+  @Min(1)
+  ledger: number;
+
+  @ApiProperty({ description: 'ISO-8601 ledger close time' })
+  @IsISO8601()
+  ledgerClosedAt: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  transactionHash?: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  pagingToken: string;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  topics?: string[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  value?: unknown;
+
+  @ApiPropertyOptional({ default: true })
+  @IsOptional()
+  @IsBoolean()
+  inSuccessfulContractCall?: boolean;
+}

--- a/harvest-finance/backend/src/webhooks/dto/payment-webhook.dto.ts
+++ b/harvest-finance/backend/src/webhooks/dto/payment-webhook.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsEnum,
+  IsISO8601,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator';
+import { ExternalPaymentEventType } from '../../vaults/dto/external-payment-notification.dto';
+
+export { ExternalPaymentEventType as PaymentWebhookEventType };
+
+export class PaymentWebhookDto {
+  @ApiProperty({ description: 'Unique idempotency key from the payment provider' })
+  @IsString()
+  @IsNotEmpty()
+  eventId: string;
+
+  @ApiProperty({ enum: ExternalPaymentEventType })
+  @IsEnum(ExternalPaymentEventType)
+  eventType: ExternalPaymentEventType;
+
+  @ApiProperty({ format: 'uuid' })
+  @IsUUID()
+  depositId: string;
+
+  @ApiProperty({ description: 'On-chain or provider transaction hash' })
+  @IsString()
+  @IsNotEmpty()
+  transactionHash: string;
+
+  @ApiPropertyOptional({ description: 'Stellar network transaction identifier' })
+  @IsOptional()
+  @IsString()
+  stellarTransactionId?: string;
+
+  @ApiPropertyOptional({ description: 'ISO-8601 timestamp from the provider' })
+  @IsOptional()
+  @IsISO8601()
+  occurredAt?: string;
+}

--- a/harvest-finance/backend/src/webhooks/dto/webhook-response.dto.ts
+++ b/harvest-finance/backend/src/webhooks/dto/webhook-response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class WebhookAcceptedResponseDto {
+  @ApiProperty({ example: true })
+  accepted: boolean;
+
+  @ApiProperty({ example: 'evt_123' })
+  eventId: string;
+
+  @ApiProperty({
+    description: 'True when the event was already processed (idempotent replay)',
+    example: false,
+  })
+  duplicate: boolean;
+}

--- a/harvest-finance/backend/src/webhooks/guards/webhook-signature.guard.ts
+++ b/harvest-finance/backend/src/webhooks/guards/webhook-signature.guard.ts
@@ -1,0 +1,68 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Reflector } from '@nestjs/core';
+import type { RawBodyRequest } from '@nestjs/common';
+import type { Request } from 'express';
+import {
+  WEBHOOK_HMAC_KEY,
+  WEBHOOK_SECRET_ENV,
+  WEBHOOK_SIGNATURE_HEADER,
+  WebhookSecretKind,
+} from '../constants';
+import { WebhookSignatureService } from '../webhook-signature.service';
+
+@Injectable()
+export class WebhookSignatureGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly config: ConfigService,
+    private readonly signatureService: WebhookSignatureService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const kind = this.reflector.get<WebhookSecretKind>(
+      WEBHOOK_HMAC_KEY,
+      context.getHandler(),
+    );
+
+    if (!kind) {
+      throw new UnauthorizedException('Webhook authentication is not configured');
+    }
+
+    const envKey = WEBHOOK_SECRET_ENV[kind];
+    const secret = this.config.get<string>(envKey);
+    if (!secret) {
+      throw new UnauthorizedException('Webhook signing secret is not configured');
+    }
+
+    const request = context
+      .switchToHttp()
+      .getRequest<RawBodyRequest<Request>>();
+    const signature = request.headers[WEBHOOK_SIGNATURE_HEADER];
+
+    const rawBody =
+      request.rawBody ??
+      Buffer.from(
+        typeof request.body === 'string'
+          ? request.body
+          : JSON.stringify(request.body ?? {}),
+      );
+
+    if (
+      !this.signatureService.verify(
+        secret,
+        rawBody,
+        Array.isArray(signature) ? signature[0] : signature,
+      )
+    ) {
+      throw new UnauthorizedException('Invalid webhook signature');
+    }
+
+    return true;
+  }
+}

--- a/harvest-finance/backend/src/webhooks/webhook-signature.service.spec.ts
+++ b/harvest-finance/backend/src/webhooks/webhook-signature.service.spec.ts
@@ -1,0 +1,29 @@
+import { WebhookSignatureService } from './webhook-signature.service';
+
+describe('WebhookSignatureService', () => {
+  const service = new WebhookSignatureService();
+  const secret = 'test-secret';
+  const body = Buffer.from(JSON.stringify({ eventId: 'evt_1' }));
+
+  it('accepts a valid sha256= signature', () => {
+    const signature = service.sign(secret, body);
+    expect(service.verify(secret, body, signature)).toBe(true);
+  });
+
+  it('accepts a bare hex digest', () => {
+    const signature = service.sign(secret, body).replace('sha256=', '');
+    expect(service.verify(secret, body, signature)).toBe(true);
+  });
+
+  it('rejects an invalid signature', () => {
+    expect(service.verify(secret, body, 'sha256=' + 'a'.repeat(64))).toBe(
+      false,
+    );
+  });
+
+  it('rejects a tampered body', () => {
+    const signature = service.sign(secret, body);
+    const tampered = Buffer.from(JSON.stringify({ eventId: 'evt_2' }));
+    expect(service.verify(secret, tampered, signature)).toBe(false);
+  });
+});

--- a/harvest-finance/backend/src/webhooks/webhook-signature.service.ts
+++ b/harvest-finance/backend/src/webhooks/webhook-signature.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import { createHmac, timingSafeEqual } from 'crypto';
+
+@Injectable()
+export class WebhookSignatureService {
+  /**
+   * Verifies an HMAC-SHA256 signature over the raw request body.
+   * Accepts `sha256=<hex>` or a bare hex digest in the signature header.
+   */
+  verify(secret: string, rawBody: Buffer | string, signatureHeader?: string): boolean {
+    if (!secret || !signatureHeader) {
+      return false;
+    }
+
+    const provided = this.normalizeSignature(signatureHeader);
+    if (!provided || !/^[a-f0-9]{64}$/i.test(provided)) {
+      return false;
+    }
+
+    const expected = createHmac('sha256', secret)
+      .update(rawBody)
+      .digest('hex');
+
+    try {
+      return timingSafeEqual(
+        Buffer.from(expected, 'hex'),
+        Buffer.from(provided, 'hex'),
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  /** Builds a signature header value for outbound tests and integrations. */
+  sign(secret: string, rawBody: Buffer | string): string {
+    const digest = createHmac('sha256', secret).update(rawBody).digest('hex');
+    return `sha256=${digest}`;
+  }
+
+  private normalizeSignature(signatureHeader: string): string {
+    const trimmed = signatureHeader.trim();
+    if (trimmed.startsWith('sha256=')) {
+      return trimmed.slice('sha256='.length);
+    }
+    return trimmed;
+  }
+}

--- a/harvest-finance/backend/src/webhooks/webhooks.controller.ts
+++ b/harvest-finance/backend/src/webhooks/webhooks.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+} from '@nestjs/common';
+import {
+  ApiHeader,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { SkipThrottle } from '@nestjs/throttler';
+import { WEBHOOK_SIGNATURE_HEADER } from './constants';
+import { WebhookHmac } from './decorators/webhook-hmac.decorator';
+import { ChainEventWebhookDto } from './dto/chain-event-webhook.dto';
+import { PaymentWebhookDto } from './dto/payment-webhook.dto';
+import { WebhookAcceptedResponseDto } from './dto/webhook-response.dto';
+import { WebhooksService } from './webhooks.service';
+
+@ApiTags('Webhooks')
+@SkipThrottle()
+@Controller({
+  path: 'webhooks',
+  version: '1',
+})
+export class WebhooksController {
+  constructor(private readonly webhooksService: WebhooksService) {}
+
+  @Post('payments')
+  @WebhookHmac('payments')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Receive external payment confirmation webhooks',
+    description:
+      'Processes payment confirmations from external providers. ' +
+      'Requires an HMAC-SHA256 signature of the raw JSON body in the ' +
+      `${WEBHOOK_SIGNATURE_HEADER} header (format: sha256=<hex>).`,
+  })
+  @ApiHeader({
+    name: WEBHOOK_SIGNATURE_HEADER,
+    required: true,
+    description: 'HMAC-SHA256 signature of the raw request body',
+  })
+  @ApiResponse({ status: 200, type: WebhookAcceptedResponseDto })
+  @ApiResponse({ status: 401, description: 'Invalid or missing signature' })
+  async receivePayment(
+    @Body() body: PaymentWebhookDto,
+  ): Promise<WebhookAcceptedResponseDto> {
+    return this.webhooksService.handlePaymentWebhook(body);
+  }
+
+  @Post('chain-events')
+  @WebhookHmac('chain-events')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Receive external chain event webhooks',
+    description:
+      'Ingests Soroban or other chain events pushed by an external indexer. ' +
+      'Requires an HMAC-SHA256 signature of the raw JSON body.',
+  })
+  @ApiHeader({
+    name: WEBHOOK_SIGNATURE_HEADER,
+    required: true,
+    description: 'HMAC-SHA256 signature of the raw request body',
+  })
+  @ApiResponse({ status: 200, type: WebhookAcceptedResponseDto })
+  @ApiResponse({ status: 401, description: 'Invalid or missing signature' })
+  async receiveChainEvent(
+    @Body() body: ChainEventWebhookDto,
+  ): Promise<WebhookAcceptedResponseDto> {
+    return this.webhooksService.handleChainEventWebhook(body);
+  }
+}

--- a/harvest-finance/backend/src/webhooks/webhooks.module.ts
+++ b/harvest-finance/backend/src/webhooks/webhooks.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { VaultsModule } from '../vaults/vaults.module';
+import { SorobanModule } from '../soroban/soroban.module';
+import { WebhookSignatureGuard } from './guards/webhook-signature.guard';
+import { WebhookSignatureService } from './webhook-signature.service';
+import { WebhooksController } from './webhooks.controller';
+import { WebhooksService } from './webhooks.service';
+
+@Module({
+  imports: [ConfigModule, VaultsModule, SorobanModule],
+  controllers: [WebhooksController],
+  providers: [WebhooksService, WebhookSignatureService, WebhookSignatureGuard],
+  exports: [WebhookSignatureService],
+})
+export class WebhooksModule {}

--- a/harvest-finance/backend/src/webhooks/webhooks.service.spec.ts
+++ b/harvest-finance/backend/src/webhooks/webhooks.service.spec.ts
@@ -1,0 +1,83 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExternalPaymentEventType } from '../vaults/dto/external-payment-notification.dto';
+import { VaultsService } from '../vaults/vaults.service';
+import { SorobanIndexerService } from '../soroban/soroban-indexer.service';
+import { WebhooksService } from './webhooks.service';
+import { PaymentWebhookEventType } from './dto/payment-webhook.dto';
+
+describe('WebhooksService', () => {
+  let service: WebhooksService;
+  let vaultsService: { applyExternalPaymentNotification: jest.Mock };
+  let sorobanIndexer: { ingestExternalEvent: jest.Mock };
+
+  beforeEach(async () => {
+    vaultsService = {
+      applyExternalPaymentNotification: jest.fn().mockResolvedValue({
+        deposit: { id: 'dep-1' },
+        status: 'CONFIRMED',
+        duplicate: false,
+      }),
+    };
+    sorobanIndexer = {
+      ingestExternalEvent: jest.fn().mockResolvedValue({ stored: true }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhooksService,
+        { provide: VaultsService, useValue: vaultsService },
+        { provide: SorobanIndexerService, useValue: sorobanIndexer },
+      ],
+    }).compile();
+
+    service = module.get(WebhooksService);
+  });
+
+  it('delegates payment webhooks to VaultsService', async () => {
+    const response = await service.handlePaymentWebhook({
+      eventId: 'evt_pay_1',
+      eventType: PaymentWebhookEventType.PAYMENT_CONFIRMED,
+      depositId: '550e8400-e29b-41d4-a716-446655440000',
+      transactionHash: 'tx_abc',
+    });
+
+    expect(vaultsService.applyExternalPaymentNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: ExternalPaymentEventType.PAYMENT_CONFIRMED,
+        externalEventId: 'evt_pay_1',
+      }),
+    );
+    expect(response).toEqual({
+      accepted: true,
+      eventId: 'evt_pay_1',
+      duplicate: false,
+    });
+  });
+
+  it('delegates chain event webhooks to SorobanIndexerService', async () => {
+    const response = await service.handleChainEventWebhook({
+      eventId: 'evt_chain_1',
+      type: 'contract' as any,
+      ledger: 100,
+      ledgerClosedAt: '2026-06-02T10:00:00.000Z',
+      pagingToken: 'token_1',
+    });
+
+    expect(sorobanIndexer.ingestExternalEvent).toHaveBeenCalled();
+    expect(response.duplicate).toBe(false);
+  });
+
+  it('marks duplicate chain events when nothing was stored', async () => {
+    sorobanIndexer.ingestExternalEvent.mockResolvedValue({ stored: false });
+
+    const response = await service.handleChainEventWebhook({
+      eventId: 'evt_chain_dup',
+      type: 'contract' as any,
+      ledger: 100,
+      ledgerClosedAt: '2026-06-02T10:00:00.000Z',
+      pagingToken: 'token_dup',
+    });
+
+    expect(response.duplicate).toBe(true);
+  });
+});

--- a/harvest-finance/backend/src/webhooks/webhooks.service.ts
+++ b/harvest-finance/backend/src/webhooks/webhooks.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { VaultsService } from '../vaults/vaults.service';
+import { SorobanIndexerService } from '../soroban/soroban-indexer.service';
+import { PaymentWebhookDto } from './dto/payment-webhook.dto';
+import { ChainEventWebhookDto } from './dto/chain-event-webhook.dto';
+import { WebhookAcceptedResponseDto } from './dto/webhook-response.dto';
+
+@Injectable()
+export class WebhooksService {
+  constructor(
+    private readonly vaultsService: VaultsService,
+    private readonly sorobanIndexer: SorobanIndexerService,
+  ) {}
+
+  async handlePaymentWebhook(
+    dto: PaymentWebhookDto,
+  ): Promise<WebhookAcceptedResponseDto> {
+    const result = await this.vaultsService.applyExternalPaymentNotification({
+      depositId: dto.depositId,
+      eventType: dto.eventType,
+      transactionHash: dto.transactionHash,
+      stellarTransactionId: dto.stellarTransactionId ?? null,
+      externalEventId: dto.eventId,
+      occurredAt: dto.occurredAt ? new Date(dto.occurredAt) : undefined,
+    });
+
+    return {
+      accepted: true,
+      eventId: dto.eventId,
+      duplicate: result.duplicate,
+    };
+  }
+
+  async handleChainEventWebhook(
+    dto: ChainEventWebhookDto,
+  ): Promise<WebhookAcceptedResponseDto> {
+    const result = await this.sorobanIndexer.ingestExternalEvent(dto);
+
+    return {
+      accepted: true,
+      eventId: dto.eventId,
+      duplicate: !result.stored,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Adds HMAC-verified webhook endpoints for external payment confirmations and chain events
- Payment webhooks update deposit status via the existing deposit event log (idempotent replays)
- Chain event webhooks ingest into the Soroban indexer store using the same upsert path as the background poller

## Purpose / Motivation
Issue #439 (#926) decouples external systems from polling the API. Providers can push signed events asynchronously instead of repeatedly querying Harvest Finance.

## Changes Made
- `POST /api/v1/webhooks/payments` — `payment.confirmed` / `payment.failed`
- `POST /api/v1/webhooks/chain-events` — Soroban-style event ingestion (idempotent on `eventId`)
- HMAC-SHA256 via `x-webhook-signature` (`sha256=<hex>`) with `WEBHOOK_PAYMENTS_HMAC_SECRET` and `WEBHOOK_CHAIN_EVENTS_HMAC_SECRET`
- Enables `rawBody` in Nest bootstrap so signatures match the exact JSON payload
- Unit tests for signature verification and webhook service delegation
- API docs updated in `docs/api/README.md`

## How to Test
1. Set `WEBHOOK_PAYMENTS_HMAC_SECRET` and `WEBHOOK_CHAIN_EVENTS_HMAC_SECRET` (dev defaults exist in development).
2. Sign and POST a payment payload to `/api/v1/webhooks/payments`; expect `200` with `{ "accepted": true, "duplicate": false }`.
3. Replay the same payload; expect `duplicate: true`.
4. POST a chain event to `/api/v1/webhooks/chain-events`; verify it appears via `GET /api/v1/soroban/events`.
5. Send a bad signature; expect `401`.
6. Run `npx jest src/webhooks` in `harvest-finance/backend`.

## Breaking Changes
- None.

## Related Issues
Closes code-flexing/Harvest-Finance#439

## Checklist
- [x] Tests added/updated (webhook unit tests pass)
- [x] Documentation updated
- [ ] Full backend `npm run build` (pre-existing TS errors elsewhere in repo)