### PR TITLE
feat: add graceful shutdown for websockets and implement multi-chain adapters

### DIFF
--- a/harvest-finance/backend/src/main.ts
+++ b/harvest-finance/backend/src/main.ts
@@ -131,7 +131,45 @@ async function bootstrap() {
 
   const configService = app.get(ConfigService);
   const port = configService.get<number>('PORT') || 5000;
-  await app.listen(port);
+
+  const server = await app.listen(port);
   console.log(`Application is running on: http://localhost:${port}`);
+
+  // Graceful shutdown handler for WebSocket connections
+  const gracefulShutdown = async (signal: string) => {
+    console.log(`Received ${signal}, closing WebSocket connections gracefully...`);
+
+    try {
+      // Get Socket.io server instance from the app
+      const httpServer = app.getHttpServer();
+
+      // Close Socket.io connections
+      const ioAdapter = app.get(IoAdapter);
+      if (ioAdapter && ioAdapter.socketServer) {
+        ioAdapter.socketServer.close();
+      }
+
+      // Close HTTP server
+      await new Promise<void>((resolve, reject) => {
+        httpServer.close((err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+
+      // Close NestJS app
+      await app.close();
+
+      console.log('Graceful shutdown completed');
+      process.exit(0);
+    } catch (error) {
+      console.error('Error during graceful shutdown:', error);
+      process.exit(1);
+    }
+  };
+
+  // Register shutdown signal handlers
+  process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+  process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 }
 bootstrap();

--- a/harvest-finance/backend/src/multi-chain/adapters/ethereum-yield.adapter.ts
+++ b/harvest-finance/backend/src/multi-chain/adapters/ethereum-yield.adapter.ts
@@ -1,0 +1,113 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ethers } from 'ethers';
+import { Repository } from 'typeorm';
+import { User } from '../../database/entities/user.entity';
+import {
+  ChainAdapter,
+  ChainYield,
+} from '../interfaces/chain-adapter.interface';
+
+/**
+ * Ethereum L1 implementation of `ChainAdapter`. Reads ERC-20 vault token balances
+ * via ethers.js and maps them to `ChainYield` positions for users with a
+ * linked `ethereumAddress`.
+ */
+@Injectable()
+export class EthereumYieldAdapter implements ChainAdapter {
+  readonly chain = 'ethereum';
+
+  constructor(
+    @InjectRepository(User)
+    private readonly users: Repository<User>,
+    private readonly config: ConfigService,
+  ) {}
+
+  async getYieldsForUser(userId: string): Promise<ChainYield[]> {
+    try {
+      const wallet = await this.resolveWallet(userId);
+      if (!wallet) return [];
+
+      const rpcUrl = this.config.get<string>('ETHEREUM_RPC_URL');
+      if (!rpcUrl) return [];
+
+      const vaultConfigs = this.parseVaultConfigs(
+        this.config.get<string>('ETHEREUM_VAULT_CONFIGS'),
+      );
+      if (vaultConfigs.length === 0) return [];
+
+      const provider = new ethers.JsonRpcProvider(rpcUrl);
+      const yields: ChainYield[] = [];
+
+      for (const vault of vaultConfigs) {
+        try {
+          const contract = new ethers.Contract(
+            vault.vaultAddress,
+            ['function balanceOf(address) view returns (uint256)'],
+            provider,
+          );
+
+          const balance = await contract.balanceOf(wallet);
+          const principal = Number(ethers.formatUnits(balance, vault.decimals));
+
+          if (principal <= 0) continue;
+
+          yields.push({
+            chain: this.chain,
+            positionId: vault.vaultAddress,
+            positionName: vault.name,
+            principal: principal.toFixed(7),
+            asset: {
+              code: vault.assetCode,
+              issuer: vault.vaultAddress,
+            },
+            apr: vault.apr ?? null,
+            estimatedAnnualYield:
+              vault.apr != null
+                ? ((principal * vault.apr) / 100).toFixed(7)
+                : null,
+            metadata: {
+              vaultAddress: vault.vaultAddress,
+              decimals: vault.decimals,
+            },
+          });
+        } catch {
+          continue;
+        }
+      }
+
+      return yields;
+    } catch {
+      return [];
+    }
+  }
+
+  private async resolveWallet(userId: string): Promise<string | null> {
+    const user = await this.users.findOne({
+      where: { id: userId },
+      select: ['id', 'ethereumAddress'],
+    });
+    const address = (user as any)?.ethereumAddress?.trim();
+    return address && address.length > 0 ? address : null;
+  }
+
+  private parseVaultConfigs(
+    configStr: string | undefined,
+  ): Array<{
+    vaultAddress: string;
+    name: string;
+    assetCode: string;
+    decimals: number;
+    apr: number | null;
+  }> {
+    if (!configStr) return [];
+
+    try {
+      const configs = JSON.parse(configStr);
+      return Array.isArray(configs) ? configs : [];
+    } catch {
+      return [];
+    }
+  }
+}

--- a/harvest-finance/backend/src/multi-chain/adapters/polygon-yield.adapter.ts
+++ b/harvest-finance/backend/src/multi-chain/adapters/polygon-yield.adapter.ts
@@ -1,0 +1,113 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ethers } from 'ethers';
+import { Repository } from 'typeorm';
+import { User } from '../../database/entities/user.entity';
+import {
+  ChainAdapter,
+  ChainYield,
+} from '../interfaces/chain-adapter.interface';
+
+/**
+ * Polygon implementation of `ChainAdapter`. Reads ERC-20 vault token balances
+ * via ethers.js and maps them to `ChainYield` positions for users with a
+ * linked `polygonAddress`.
+ */
+@Injectable()
+export class PolygonYieldAdapter implements ChainAdapter {
+  readonly chain = 'polygon';
+
+  constructor(
+    @InjectRepository(User)
+    private readonly users: Repository<User>,
+    private readonly config: ConfigService,
+  ) {}
+
+  async getYieldsForUser(userId: string): Promise<ChainYield[]> {
+    try {
+      const wallet = await this.resolveWallet(userId);
+      if (!wallet) return [];
+
+      const rpcUrl = this.config.get<string>('POLYGON_RPC_URL');
+      if (!rpcUrl) return [];
+
+      const vaultConfigs = this.parseVaultConfigs(
+        this.config.get<string>('POLYGON_VAULT_CONFIGS'),
+      );
+      if (vaultConfigs.length === 0) return [];
+
+      const provider = new ethers.JsonRpcProvider(rpcUrl);
+      const yields: ChainYield[] = [];
+
+      for (const vault of vaultConfigs) {
+        try {
+          const contract = new ethers.Contract(
+            vault.vaultAddress,
+            ['function balanceOf(address) view returns (uint256)'],
+            provider,
+          );
+
+          const balance = await contract.balanceOf(wallet);
+          const principal = Number(ethers.formatUnits(balance, vault.decimals));
+
+          if (principal <= 0) continue;
+
+          yields.push({
+            chain: this.chain,
+            positionId: vault.vaultAddress,
+            positionName: vault.name,
+            principal: principal.toFixed(7),
+            asset: {
+              code: vault.assetCode,
+              issuer: vault.vaultAddress,
+            },
+            apr: vault.apr ?? null,
+            estimatedAnnualYield:
+              vault.apr != null
+                ? ((principal * vault.apr) / 100).toFixed(7)
+                : null,
+            metadata: {
+              vaultAddress: vault.vaultAddress,
+              decimals: vault.decimals,
+            },
+          });
+        } catch {
+          continue;
+        }
+      }
+
+      return yields;
+    } catch {
+      return [];
+    }
+  }
+
+  private async resolveWallet(userId: string): Promise<string | null> {
+    const user = await this.users.findOne({
+      where: { id: userId },
+      select: ['id', 'polygonAddress'],
+    });
+    const address = (user as any)?.polygonAddress?.trim();
+    return address && address.length > 0 ? address : null;
+  }
+
+  private parseVaultConfigs(
+    configStr: string | undefined,
+  ): Array<{
+    vaultAddress: string;
+    name: string;
+    assetCode: string;
+    decimals: number;
+    apr: number | null;
+  }> {
+    if (!configStr) return [];
+
+    try {
+      const configs = JSON.parse(configStr);
+      return Array.isArray(configs) ? configs : [];
+    } catch {
+      return [];
+    }
+  }
+}

--- a/harvest-finance/backend/src/multi-chain/multi-chain.module.ts
+++ b/harvest-finance/backend/src/multi-chain/multi-chain.module.ts
@@ -5,6 +5,8 @@ import { AuthModule } from '../auth/auth.module';
 import { Deposit } from '../database/entities/deposit.entity';
 import { User } from '../database/entities/user.entity';
 import { Vault } from '../database/entities/vault.entity';
+import { EthereumYieldAdapter } from './adapters/ethereum-yield.adapter';
+import { PolygonYieldAdapter } from './adapters/polygon-yield.adapter';
 import { SolanaYieldAdapter } from './adapters/solana-yield.adapter';
 import { StellarYieldAdapter } from './adapters/stellar-yield.adapter';
 import { CHAIN_ADAPTERS } from './interfaces/chain-adapter.interface';
@@ -21,13 +23,22 @@ import { MultiChainService } from './multi-chain.service';
   providers: [
     StellarYieldAdapter,
     SolanaYieldAdapter,
+    PolygonYieldAdapter,
+    EthereumYieldAdapter,
     {
       provide: CHAIN_ADAPTERS,
       useFactory: (
         stellar: StellarYieldAdapter,
         solana: SolanaYieldAdapter,
-      ) => [stellar, solana],
-      inject: [StellarYieldAdapter, SolanaYieldAdapter],
+        polygon: PolygonYieldAdapter,
+        ethereum: EthereumYieldAdapter,
+      ) => [stellar, solana, polygon, ethereum],
+      inject: [
+        StellarYieldAdapter,
+        SolanaYieldAdapter,
+        PolygonYieldAdapter,
+        EthereumYieldAdapter,
+      ],
     },
     MultiChainService,
   ],


### PR DESCRIPTION
## What
Added graceful WebSocket shutdown handling and implemented Polygon/Ethereum chain adapters for multi-chain yield aggregation.

## Issues Resolved
Closes #433
Closes #434
Closes #435
Closes #436

## Changes

### #433 - Add graceful shutdown handling for WebSocket connections
- Hook into application shutdown lifecycle in main.ts
- Close Socket.io server before process exit
- Prevents client-side reconnection storms

### #434 - Implement Polygon chain adapter  
- PolygonYieldAdapter reads ERC-20 vault balances via ethers.js
- Follows ChainAdapter interface pattern
- Supports configurable vault addresses and decimals

### #435 - Implement Ethereum L1 chain adapter
- EthereumYieldAdapter for Ethereum mainnet vault strategies
- RPC-based balance fetching with graceful error handling
- Configuration via environment variables

### #436 - Implement Solana chain adapter (completed)
- Solana adapter was already implemented in codebase